### PR TITLE
Update Hardcoded Repo Name in Workflow

### DIFF
--- a/.github/workflows/gh-test.yml
+++ b/.github/workflows/gh-test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: src/github.com/k14s/imgpkg
+        path: src/github.com/${{ github.repository }}
     - name: Run Tests
       run: |
         set -e -x
@@ -33,7 +33,7 @@ jobs:
         eval $(minikube docker-env --shell=bash)
 
         export GOPATH=$(echo `pwd`)
-        cd src/github.com/k14s/imgpkg
+        cd src/github.com/${{ github.repository }}
 
         # deploy local registry and run tests
         ./hack/test-all-minikube-local-registry.sh


### PR DESCRIPTION
Updating checkout step to use `${{ github.repository }}` for its path to help with transitioning to new org. Should be aliased, but might be nice to avoid confusion if someone is reviewing CI process.