### PR TITLE
Enforce the ImagesLock `kind` when validating bundles

### DIFF
--- a/pkg/imgpkg/cmd/pull.go
+++ b/pkg/imgpkg/cmd/pull.go
@@ -162,6 +162,9 @@ func (o *PullOptions) getRefFromFlags() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if bundleLock.Kind != lf.BundleLockKind {
+		return "", fmt.Errorf("Invalid `kind` in lockfile at %s. Expected: %s, got: %s", ref, lf.BundleLockKind, bundleLock.Kind)
+	}
 	return bundleLock.Spec.Image.DigestRef, nil
 }
 

--- a/pkg/imgpkg/cmd/pull_test.go
+++ b/pkg/imgpkg/cmd/pull_test.go
@@ -4,6 +4,10 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -29,5 +33,38 @@ func TestImageAndBundleAndLockError(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "Expected only one of image, bundle, or lock") {
 		t.Fatalf("Expected error to contain message about invalid flags, got: %s", err)
+	}
+}
+
+func TestInvalidBundleLockKind(t *testing.T) {
+	tempDir := os.TempDir()
+
+	workingDir := filepath.Join(tempDir, "imgpkg-pull-units-invalid-kind")
+	defer Cleanup(workingDir)
+	err := os.MkdirAll(workingDir, 0700)
+	if err != nil {
+		t.Fatalf("Failed to setup test: %s", err)
+	}
+
+	lockFilePath := filepath.Join(workingDir, "bundlelock.yml")
+	ioutil.WriteFile(lockFilePath, []byte(`
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: invalid-value
+spec:
+  image:
+    url: index.docker.io/k8slt/test
+    tag: latest
+`), 0600)
+
+	pull := PullOptions{LockInputFlags: LockInputFlags{LockFilePath: lockFilePath}}
+	err = pull.Run()
+	if err == nil {
+		t.Fatalf("Expected validations to err, but did not")
+	}
+
+	reg := regexp.MustCompile("Invalid `kind` in lockfile at .*imgpkg-pull-units-invalid-kind/bundlelock\\.yml. Expected: BundleLock, got: invalid-value")
+	if !reg.MatchString(err.Error()) {
+		t.Fatalf("Expected error to contain message about invalid bundlelock kind, got: %s", err)
 	}
 }

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -236,6 +236,9 @@ func (o *PushOptions) validateBundle(registry ctlimg.Registry) error {
 	if err != nil {
 		return fmt.Errorf("Unmarshalling image lock: %s", err)
 	}
+	if imgLock.Kind != lf.ImagesLockKind {
+		return fmt.Errorf("Invalid `kind` in lockfile at %s. Expected: %s, got: %s", filepath.Join(bundlePaths[0], lf.ImageLockFile), lf.ImagesLockKind, imgLock.Kind)
+	}
 
 	bundles, err := imgLock.CheckForBundles(registry)
 	if err != nil {


### PR DESCRIPTION
Unsure on the error message here. Too verbose? It outputs the entire path to your images.yml file.