### PR TITLE
Update `commands.md` docs for `--image`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,65 +7,17 @@
 
 ## Push
 
-Push allows users to create an image or a bundle from files or directories on their local file systems and
+Push allows users to create a bundle from files or directories on their local file systems and
 then push the resulting artifact to a registry. For example,
 
 `$ imgpkg push -f my-bundle -b index.docker.io/k8slt/sample-bundle`
 
-will push a bundle image containing the `my-bundle` directory to `index.docker.io/k8slt/sample-bundle`, while
+will push a bundle containing the `my-bundle` directory to `index.docker.io/k8slt/sample-bundle`.
 
-`$ imgpkg push -f my-image -i index.docker.io/k8slt/sample-image`
+The `-f` flag can be used multiple times to add different files or directories to the bundle.
 
-will push a generic image containing the `my-image` directory to `index.docker.io/k8slt/sample-image`.
-
-In both cases, the `-f` flag can be used multiple times to add different files or directories to the bundle.
-
-The `-b`/`--bundle` or `-i`/`--image` flags are used to specify the destination of the push.
+Use the `-b`/`--bundle` flag to specify the destination of the push.
 If the specified destination does not include a tag, the artifact will be pushed with the default tag `:latest`.
-
-### Pushing a bundle
-
-If a `.imgpkg` directory is present in any of the input directories, imgpkg will push a bundle that has the list of referenced images and any other metadata contained within the `.imgpkg/` directory associated with it.
-
-There are a few restrictions when creating a bundle from directories that contain a `.imgpkg` directory, namely:
-
-* Only one `.imgpkg` directory is allowed across all directories provided via `-f`. So, the following example will cause an error:
-
-  `$ imgpkg -f foo -f bar -b <bundle>`
-
-  given:
-
-  ```
-  foo/
-  L .imgpkg/
-
-  bar/
-  L .imgpkg/
-  ```
-
-  This restriction ensures there is a single source of bundle metadata and referenced images.
-
-* The `.imgpkg` directory must be a direct child of one of the input directories. For example,
-
-  `$ imgpkg -f foo/ -b <bundle>`
-
-  will fail if `foo/` has the structure
-
-  ```
-    foo/
-    L bar/
-      L .imgpkg
-  ```
-
-  This prevents any confusion around the scope that the `.impkg` metadata applies to.
-
-* The `.imgpkg` directory must contain a single
-  [ImagesLock](resources.md#imageslock) file names `images.yml`, though it can contain an empty list
-  of references.
-
-  This provides a guarantee to consumers that the file will always be present
-  and is safe to rely on in automation that consumes bundles.
-
 
 ### Generating a [BundleLock](resources.md#bundlelock)
 
@@ -74,28 +26,18 @@ There are a few restrictions when creating a bundle from directories that contai
 `$ impgpkg push -f my-bundle -b index.docker.io/k8slt/sample-bundle:v0.1.0 --lock-output
 bundle.lock.yml`
 
-will output a [BundleLock](resources.md#bundlelock) file to `bundle.lock.yml`. If another image in the repository is later given the same tag (`v0.1.0`), the BundleLock will guarantee users continue to reference the original bundle by its digest.
-
-### Pushing an image
-
-If a bundle is not desired then users still have the ability to push a generic image. To push an image, use the `--image`/`-i` flag:
-
-`$ imgpkg push -f my-image -i index.docker.io/k8slt/sample-image`
-
-If the `-i/--image` flag is used with inputs that also contain a `.imgpkg`
-directory, imgpkg will error.
-
+will output a [BundleLock](resources.md#bundlelock) file to `bundle.lock.yml`. If another bundle image in the repository is later given the same tag (`v0.1.0`), the BundleLock will guarantee users continue to reference the original bundle by its digest.
 ## Pull
 
 ### Pulling an artifact
 
-After pushing bundles or images to a registry, users can retrieve them with `imgpkg pull`. For example,
+After pushing bundles to a registry, users can retrieve them with `imgpkg pull`. For example,
 
 `$ imgpkg pull -b index.docker.io/k8slt/sample-bundle -o my-bundle`
 
 will pull a bundle from `index.docker.io/k8slt/sample-bundle` and extract its
 contents in to the `my-bundle` directory, which gets created if it does not
-exist. The same workflow applies to images pulled with imgpkg.
+exist.
 
 When pulling a bundle, imgpkg must ensure that the referenced images are updated
 to account for any relocations. Because images are referenced by digest, imgpkg
@@ -120,33 +62,20 @@ or into a local tarball for air-gapped relocation using `--to-tar`:
 The bundle image at `index.docker.io/k8slt/sample-bundle` will be copied thickly (bundle image + all referenced images)
 to either destination.
 
-### Copying an image
-
-Users are able to copy an image from a registry to another registry, as well:
-
-`$ imgpkg copy -i index.docker.io/k8slt/sample-image --to-repo internal-registry/sample-image-name`
-
-or into a local tarball for air-gapped relocation:
-
-`$ imgpkg copy -i index.docker.io/k8slt/sample-image --to-tar=/Volumes/secure-thumb/image.tar`
-
 ### Copying via lock files
 
-Users can also input lock files, either a [BundleLock](resources.md#bundlelock) or
-[ImagesLock](resources.md#imageslock), to the copy command via the `--lock` flag.
-This will copy a bundle, for BundleLocks, or a list of images, for ImagesLocks.
-For example,
+Users can also input a [BundleLock](resources.md#bundlelock) file to the copy command via the `--lock` flag.
 
-`$ imgpkg copy --lock images.yml --to-repo internal-registry/my-images`
+`$ imgpkg copy --lock bundle-lock.yml --to-repo internal-registry/my-images`
 
-will copy the images references within the ImagesLock file, `images.yml`, to the
+will copy the images references within the BundleLock file, `bundle-lock.yml`, to the
 `my-images` repository.
 
 ## Tag
 
-`imgpkg tag` supports a `list` subcommand that allows users to list the tags of images 
+`imgpkg tag` supports a `list` subcommand that allows users to list the tags of bundles 
 pushed to registries. The command features an `--image`/`-i` option that allows a user 
-to specify an image name. 
+to specify a bundle or image name. 
 
 An example of this is shown below:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,13 +11,19 @@ A bundle is an image with some additional characteristics:
   
 `imgpkg` tries to be helpful to ensure that bundles are referenced and constructed correctly, so it will error if any incompatibilities arise.
 
-The following resources are part of a bundle.
-
 ### `.imgpkg` directory
 
-Stores files with bundle information in a **required** ([ImagesLock](#imageslock)) file that stores referenced images, and in an optional ([Bundle Metadata](#bundle-metadata)) file that stores metadata describing the bundle. 
+There are a few restrictions when creating a bundle:
 
-Only one can exist per bundle and it will always be found at the top level.
+* Only one `.imgpkg` directory is allowed across all directories provided via `-f`. This restriction ensures there is a single source of bundle metadata and referenced images.
+
+* The `.imgpkg` directory must be a direct child of one of the input directories. This prevents any confusion around the scope that the `.imgpkg` metadata applies to.
+
+* The `.imgpkg` directory must contain a **required** [ImagesLock](resources.md#imageslock) file named `images.yml` that contains 0+ referenced images. This provides a guarantee to consumers that the files will always be present and is safe to rely on in automation that consumes bundles.
+
+* An optional [Bundle Metadata](#bundle-metadata) file that stores metadata describing the bundle.
+
+A bundle directory has this structure:
 
 ```
 .imgpkg/


### PR DESCRIPTION
    - Move Bundle requirements to `resources.md`
    - Remove mentions of `--image` in favor of `--bundle`
    - Remove mentions to `ImageLock` file which no longer exists