### PR TITLE
Suppress output when skipping file link or symlink

### DIFF
--- a/pkg/imgpkg/image/dir_image.go
+++ b/pkg/imgpkg/image/dir_image.go
@@ -143,8 +143,7 @@ func (i *DirImage) extractTarEntry(header *tar.Header, input io.Reader) error {
 		}
 
 	case tar.TypeLink, tar.TypeSymlink:
-		// TODO currently not implemented
-		fmt.Printf("TODO Skipping file link '%s'\n", header.Name)
+		// skipping symlinks as a security feature
 		return nil
 
 	default:


### PR DESCRIPTION
Removed repetitive "TODO Skipping file link"...  when encountering a file link or Symlink.

Q: Is there a situation where the user would need to know that the symlinks are being skipped? If so, should we document this behavior? or include a "Skipping all file and sym links" in the output when these links are detected in a layer?