### PR TITLE
Update cobrautil Dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/k14s/imgpkg
 go 1.13
 
 require (
-	github.com/cppforlife/cobrautil v0.0.0-20180924214100-a39a1714c920
+	github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72
 	github.com/cppforlife/go-cli-ui v0.0.0-20200506005011-4268990983cc
 	github.com/google/go-containerregistry v0.1.4
 	github.com/k14s/difflib v0.0.0-20201103203400-90558b9d63e4

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,11 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cppforlife/cobrautil v0.0.0-20180924214100-a39a1714c920 h1:RTikdXczo1UY3c/8WuySawdmOXQg10OuDb7s66K687I=
-github.com/cppforlife/cobrautil v0.0.0-20180924214100-a39a1714c920/go.mod h1:2w+qxVu2KSGW78Ex/XaIqfh/OvBgjEsmN53S4T8vEyA=
+github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72 h1:rPWcUBgMb1ox2eCohCuZ8gsZVe0aB5qBbYaBpdoxfCE=
+github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72/go.mod h1:2w+qxVu2KSGW78Ex/XaIqfh/OvBgjEsmN53S4T8vEyA=
 github.com/cppforlife/go-cli-ui v0.0.0-20200506005011-4268990983cc h1:Wq67+0TH61A42xWBrIeZSUxPMSmmfSkCw2T/nheUCGU=
 github.com/cppforlife/go-cli-ui v0.0.0-20200506005011-4268990983cc/go.mod h1:I0qrzCmuPWYI6kAOvkllYjaW2aovclWbJ96+v+YyHb0=
+github.com/cppforlife/go-cli-ui v0.0.0-20200716203538-1e47f820817f h1:yVW0v4zDXzJo1i8G9G3vtvNpyzhvtLalO34BsN/K88E=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=

--- a/pkg/imgpkg/cmd/imgpkg.go
+++ b/pkg/imgpkg/cmd/imgpkg.go
@@ -51,7 +51,7 @@ func NewImgpkgCmd(o *ImgpkgOptions) *cobra.Command {
 
 	// Last one runs first
 	cobrautil.VisitCommands(cmd, cobrautil.ReconfigureCmdWithSubcmd)
-	cobrautil.VisitCommands(cmd, cobrautil.ReconfigureLeafCmd)
+	cobrautil.VisitCommands(cmd, cobrautil.DisallowExtraArgs)
 
 	cobrautil.VisitCommands(cmd, cobrautil.WrapRunEForCmd(func(*cobra.Command, []string) error {
 		o.UIFlags.ConfigureUI(o.ui)

--- a/pkg/imgpkg/cmd/pull_test.go
+++ b/pkg/imgpkg/cmd/pull_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/cppforlife/go-cli-ui/ui"
 )
 
 func TestNoImageOrBundleOrLockError(t *testing.T) {
@@ -66,5 +68,22 @@ spec:
 	reg := regexp.MustCompile("Invalid `kind` in lockfile at .*imgpkg-pull-units-invalid-kind/bundlelock\\.yml. Expected: BundleLock, got: invalid-value")
 	if !reg.MatchString(err.Error()) {
 		t.Fatalf("Expected error to contain message about invalid bundlelock kind, got: %s", err)
+	}
+}
+
+func Test_Invalid_Args_Passed(t *testing.T) {
+	confUI := ui.NewConfUI(ui.NewNoopLogger())
+	defer confUI.Flush()
+
+	imgpkgCmd := NewDefaultImgpkgCmd(confUI)
+	imgpkgCmd.SetArgs([]string{"pull", "k8slt/image", "-o", "/tmp"})
+	err := imgpkgCmd.Execute()
+	if err == nil {
+		t.Fatalf("Expected error from executing imgpkg pull command: %v", err)
+	}
+
+	expected := "command 'imgpkg pull' does not accept extra arguments 'k8slt/image'"
+	if expected != err.Error() {
+		t.Fatalf("\nExpceted: %s\nGot: %s", expected, err.Error())
 	}
 }

--- a/vendor/github.com/cppforlife/cobrautil/flag_help_sections.go
+++ b/vendor/github.com/cppforlife/cobrautil/flag_help_sections.go
@@ -1,0 +1,122 @@
+package cobrautil
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type FlagHelpSection struct {
+	Title string
+
+	PrefixMatch string
+	ExactMatch  []string
+	NoneMatch   bool
+}
+
+func (s FlagHelpSection) Matches(name string) bool {
+	if len(s.PrefixMatch) > 0 && strings.HasPrefix(name, s.PrefixMatch+"-") {
+		return true
+	}
+	for _, em := range s.ExactMatch {
+		if name == em {
+			return true
+		}
+	}
+	return false
+}
+
+type flagLine struct {
+	Line        string
+	SectionIdxs []int
+}
+
+func (l flagLine) InSectionIdx(idx int) bool {
+	for _, i := range l.SectionIdxs {
+		if i == idx {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	flagHelpFuncCount = 0
+	flagNameRegexp    = regexp.MustCompile("^\\s+(\\-[a-z], )?\\-\\-([a-z\\-]+)\\s+")
+)
+
+func FlagHelpSectionsUsageTemplate(sections []FlagHelpSection) string {
+	flagHelpFuncCount += 1
+	flagHelpFuncName := fmt.Sprintf("flagsWithSections%d", flagHelpFuncCount)
+
+	cobra.AddTemplateFunc(flagHelpFuncName, func(str string) string {
+		lines := strings.Split(str, "\n")
+		flags := map[string]flagLine{}
+		flagNames := []string{}
+
+		for _, line := range lines {
+			match := flagNameRegexp.FindStringSubmatch(line)
+			flagName := match[2]
+
+			if _, found := flags[flagName]; found {
+				panic("Expected to not find multiple flags with same name")
+			}
+
+			fline := flagLine{Line: line}
+			noneMatchIdx := -1
+
+			for i, section := range sections {
+				if section.Matches(flagName) {
+					fline.SectionIdxs = append(fline.SectionIdxs, i)
+				}
+				if section.NoneMatch {
+					noneMatchIdx = i
+				}
+			}
+			if len(fline.SectionIdxs) == 0 {
+				fline.SectionIdxs = []int{noneMatchIdx}
+			}
+
+			flags[flagName] = fline
+			flagNames = append(flagNames, flagName)
+		}
+
+		sort.Strings(flagNames)
+
+		sectionsResult := []string{}
+
+		for i, section := range sections {
+			result := section.Title + "\n"
+			for _, name := range flagNames {
+				fline := flags[name]
+				if fline.InSectionIdx(i) {
+					result += fline.Line + "\n"
+				}
+			}
+			sectionsResult = append(sectionsResult, result)
+		}
+
+		return strings.TrimSpace(strings.Join(sectionsResult, "\n"))
+	})
+
+	unmodifiedCmd := &cobra.Command{}
+	usageTemplate := unmodifiedCmd.UsageTemplate()
+
+	const defaultTpl = `{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}`
+
+	if !strings.Contains(usageTemplate, defaultTpl) {
+		panic("Expected to find available flags section in spf13/cobra default usage template")
+	}
+
+	newTpl := fmt.Sprintf(`{{if .HasAvailableLocalFlags}}
+
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces | %s}}{{end}}`, flagHelpFuncName)
+
+	return strings.Replace(usageTemplate, defaultTpl, newTpl, 1)
+}

--- a/vendor/github.com/cppforlife/cobrautil/misc.go
+++ b/vendor/github.com/cppforlife/cobrautil/misc.go
@@ -7,15 +7,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
-	f(cmd)
+type ReconfigureFunc func(cmd *cobra.Command)
+
+func VisitCommands(cmd *cobra.Command, fns ...ReconfigureFunc) {
+	for _, f := range fns {
+		f(cmd)
+	}
 	for _, child := range cmd.Commands() {
-		VisitCommands(child, f)
+		VisitCommands(child, fns...)
 	}
 }
 
-func WrapRunEForCmd(additionalRunE func(*cobra.Command, []string) error) func(cmd *cobra.Command) {
+func ReconfigureLeafCmds(fs ...func(cmd *cobra.Command)) ReconfigureFunc {
 	return func(cmd *cobra.Command) {
+		if len(cmd.Commands()) > 0 {
+			return
+		}
+
+		for _, f := range fs {
+			f(cmd)
+		}
+	}
+}
+
+func WrapRunEForCmd(additionalRunE func(*cobra.Command, []string) error) ReconfigureFunc {
+	return func(cmd *cobra.Command) {
+		if cmd.RunE == nil {
+			panic(fmt.Sprintf("Internal: Command '%s' does not set RunE", cmd.CommandPath()))
+		}
+
 		origRunE := cmd.RunE
 		cmd.RunE = func(cmd2 *cobra.Command, args []string) error {
 			err := additionalRunE(cmd2, args)
@@ -26,6 +46,8 @@ func WrapRunEForCmd(additionalRunE func(*cobra.Command, []string) error) func(cm
 		}
 	}
 }
+
+// ReconfigureFuncs
 
 func ReconfigureCmdWithSubcmd(cmd *cobra.Command) {
 	if len(cmd.Commands()) == 0 {
@@ -49,26 +71,17 @@ func ReconfigureCmdWithSubcmd(cmd *cobra.Command) {
 	cmd.Short += " (" + strings.Join(strs, ", ") + ")"
 }
 
-func ReconfigureLeafCmd(cmd *cobra.Command) {
-	if len(cmd.Commands()) > 0 {
-		return
-	}
-
-	if cmd.RunE == nil {
-		panic(fmt.Sprintf("Internal: Command '%s' does not set RunE", cmd.CommandPath()))
-	}
-
-	if cmd.Args == nil {
-		origRunE := cmd.RunE
-		cmd.RunE = func(cmd2 *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("command '%s' does not accept extra arguments '%s'", args[0], cmd2.CommandPath())
-			}
-			return origRunE(cmd2, args)
+func DisallowExtraArgs(cmd *cobra.Command) {
+	WrapRunEForCmd(func(cmd2 *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return fmt.Errorf("command '%s' does not accept extra arguments '%s'", cmd2.CommandPath(), args[0])
 		}
-		cmd.Args = cobra.ArbitraryArgs
-	}
+		return nil
+	})(cmd)
+	cmd.Args = cobra.ArbitraryArgs
 }
+
+// New RunE's
 
 func ShowSubcommands(cmd *cobra.Command, args []string) error {
 	var strs []string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/cppforlife/cobrautil v0.0.0-20180924214100-a39a1714c920
+# github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72
 github.com/cppforlife/cobrautil
 # github.com/cppforlife/go-cli-ui v0.0.0-20200506005011-4268990983cc
 github.com/cppforlife/go-cli-ui/ui


### PR DESCRIPTION
Closes #44 

This was updated to assist with fixing the following GitHub issue: https://github.com/vmware-tanzu/carvel-imgpkg/issues/44. The main goal was to update the error message for when args are passed to imgpkg commands, which do not accept args at this point. Only flags with args are valid inputs to imgpkg commands.

The old error was:

```
Error: command 'foo' does not accept extra arguments 'imgpkg pull'
```

The new error will be:

```
Error: command 'imgpkg pull' does not accept extra arguments 'foo'
```