### PR TITLE
Change input flag to read image from tar

### DIFF
--- a/docs/air-gapped-workflow.md
+++ b/docs/air-gapped-workflow.md
@@ -95,7 +95,7 @@ You have two options how to transfer bundle from one registry to another:
 1. Import the bundle from your tarball to the destination registry:
 
     ```bash
-    $ imgpkg copy --from-tar /tmp/my-image.tar --to-repo registry.corp.com/apps/simple-app-bundle
+    $ imgpkg copy --tar /tmp/my-image.tar --to-repo registry.corp.com/apps/simple-app-bundle
 
     copy | importing 2 images...
     copy | importing index.docker.io/user1/simple-app-bundle@sha256:70225df0a05137ac385c95eb69f89ded3e7ef3a0c34db43d7274fd9eba3705bb -> registry.corp.com/apps/simple-app-bundle@sha256:70225df0a05137ac385c95eb69f89ded3e7ef3a0c34db43d7274fd9eba3705bb...
@@ -107,7 +107,7 @@ You have two options how to transfer bundle from one registry to another:
     The bundle, and all images referenced in the bundle, are copied to the destination registry.
 
     Flags used in the command:
-      * `--from-tar` indicates the path to a tar file containing the assets to be copied to a registry
+      * `--tar` indicates the path to a tar file containing the assets to be copied to a registry
       * `--to-repo` indicates destination bundle location in the registry
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,7 +73,7 @@ Alternatively `copy` can copy a bundle between registries which are not both acc
 ```bash
 $ imgpkg copy -b index.docker.io/k8slt/sample-bundle --to-tar=/Volumes/secure-thumb/bundle.tar
 # ... take thumb driver to a different location ...
-$ imgpkg copy --from-tar=/Volumes/secure-thumb/bundle.tar --to-repo registry.corp.com/user2/sample-bundle-name
+$ imgpkg copy --tar=/Volumes/secure-thumb/bundle.tar --to-repo registry.corp.com/user2/sample-bundle-name
 ```
 
 In either case, the bundle image and all dependent images are copied to the destination location `registry.corp.com/user2/sample-bundle-name`.

--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -64,7 +64,7 @@ func NewCopyCmd(o *CopyOptions) *cobra.Command {
 
 func (o *CopyOptions) Run() error {
 	if !o.hasOneSrc() {
-		return fmt.Errorf("Expected either --lock, --bundle (-b), --image (-i), or --from-tar as a source")
+		return fmt.Errorf("Expected either --lock, --bundle (-b), --image (-i), or --tar as a source")
 	}
 	if !o.hasOneDst() {
 		return fmt.Errorf("Expected either --to-tar or --to-repo")
@@ -81,7 +81,7 @@ func (o *CopyOptions) Run() error {
 	switch {
 	case o.isTarSrc():
 		if o.isTarDst() {
-			return fmt.Errorf("Cannot use tar source (--from-tar) with tar destination (--to-tar)")
+			return fmt.Errorf("Cannot use tar source (--tar) with tar destination (--to-tar)")
 		}
 
 		importRepo, err := regname.NewRepository(o.RepoDst)

--- a/pkg/imgpkg/cmd/copy_test.go
+++ b/pkg/imgpkg/cmd/copy_test.go
@@ -37,7 +37,7 @@ func TestMultiSrc(t *testing.T) {
 		t.Fatalf("Expected Run() to err")
 	}
 
-	if !strings.Contains(err.Error(), "Expected either --lock, --bundle (-b), --image (-i), or --from-tar as a source") {
+	if !strings.Contains(err.Error(), "Expected either --lock, --bundle (-b), --image (-i), or --tar as a source") {
 		t.Fatalf("Expected error message related to destinations, got: %s", err)
 	}
 
@@ -49,7 +49,7 @@ func TestNoSrc(t *testing.T) {
 		t.Fatalf("Expected Run() to err")
 	}
 
-	if !strings.Contains(err.Error(), "Expected either --lock, --bundle (-b), --image (-i), or --from-tar as a source") {
+	if !strings.Contains(err.Error(), "Expected either --lock, --bundle (-b), --image (-i), or --tar as a source") {
 		t.Fatalf("Expected error message related to destinations, got: %s", err)
 	}
 
@@ -61,7 +61,7 @@ func TestTarSrcWithTarDst(t *testing.T) {
 		t.Fatalf("Expected Run() to err")
 	}
 
-	if !strings.Contains(err.Error(), "Cannot use tar source (--from-tar) with tar destination (--to-tar)") {
+	if !strings.Contains(err.Error(), "Cannot use tar source (--tar) with tar destination (--to-tar)") {
 		t.Fatalf("Expected error message related to destinations, got: %s", err)
 	}
 }

--- a/pkg/imgpkg/cmd/tar_flags.go
+++ b/pkg/imgpkg/cmd/tar_flags.go
@@ -14,6 +14,5 @@ type TarFlags struct {
 
 func (s *TarFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.TarDst, "to-tar", "", "Location to write a tar file containing assets")
-	cmd.Flags().StringVar(&s.TarSrc, "from-tar", "", "Path to tar file which contains assets to be copied to a registry")
-
+	cmd.Flags().StringVar(&s.TarSrc, "tar", "", "Path to tar file which contains assets to be copied to a registry")
 }

--- a/test/e2e/copy_test.go
+++ b/test/e2e/copy_test.go
@@ -534,7 +534,7 @@ images:
 	defer os.Remove(lockFilePath)
 
 	// copy from tar to repo
-	imgpkg.Run([]string{"copy", "--from-tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockFilePath})
+	imgpkg.Run([]string{"copy", "--tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockFilePath})
 
 	relocatedBundleLock, err := lockconfig.NewBundleLockFromPath(lockFilePath)
 	if err != nil {
@@ -624,7 +624,7 @@ images:
 	defer os.Remove(lockOutputPath)
 
 	// copy from tar to repo
-	imgpkg.Run([]string{"copy", "--from-tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockOutputPath})
+	imgpkg.Run([]string{"copy", "--tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockOutputPath})
 
 	imgLock, err := lockconfig.NewImagesLockFromPath(lockOutputPath)
 	if err != nil {
@@ -701,7 +701,7 @@ images:
 	defer os.Remove(lockFilePath)
 
 	// copy from tar to repo
-	imgpkg.Run([]string{"copy", "--from-tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockFilePath})
+	imgpkg.Run([]string{"copy", "--tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockFilePath})
 
 	bundleLock, err := lockconfig.NewBundleLockFromPath(lockFilePath)
 	if err != nil {
@@ -766,7 +766,7 @@ func TestCopyImageInputToTarFileAndToADifferentRepoCheckImageLockIsGenerated(t *
 	defer os.Remove(lockOutputPath)
 
 	// copy from tar to repo
-	imgpkg.Run([]string{"copy", "--from-tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockOutputPath})
+	imgpkg.Run([]string{"copy", "--tar", tarFilePath, "--to-repo", env.RelocationRepo, "--lock-output", lockOutputPath})
 
 	imgLock, err := lockconfig.NewImagesLockFromPath(lockOutputPath)
 	if err != nil {


### PR DESCRIPTION
Update the copy command from a tar to use the flag `--tar` instead of `--from-tar` to have a more uniform UX

Closes #38 