### PR TITLE
Update help for --lock-output flag

### DIFF
--- a/pkg/imgpkg/cmd/lock_output_flags.go
+++ b/pkg/imgpkg/cmd/lock_output_flags.go
@@ -13,5 +13,5 @@ type LockOutputFlags struct {
 
 func (s *LockOutputFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&s.LockFilePath, "lock-output", "",
-		"Location to output lockfile. lockfile type (BundleLock or ImagesLock) is determined from contents moved.")
+		"Location to output the generated lockfile. Option only available when using --bundle or --lock flags")
 }


### PR DESCRIPTION
Ensure that the help of the flag `lock-output` informs the user that it is only available paired with a Bundle or a Lock file