### PR TITLE
Adding golint and goheader linters via golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.34
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,9 @@
-
-# all available settings of specific linters
-linters-settings:
-  goheader:
-    values:
-      const:
-        COMPANY: Copyright 2020 VMware, Inc.
-      # regexp:
-      
-        # AUTHOR: .*@mycompany\.com
-    template: |
-     {{ COMPANY }}
-     SPDX-License-Identifier: Apache-2.0
 linters:
   enable:
     - goheader
+    - golint
   disable-all: true
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    template-path: code-header-template.txt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    values:
+      const:
+        COMPANY: Copyright 2020 VMware, Inc.
+      # regexp:
+      
+        # AUTHOR: .*@mycompany\.com
+    template: |
+     {{ COMPANY }}
+     SPDX-License-Identifier: Apache-2.0
+linters:
+  enable:
+    - goheader
+  disable-all: true

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x -u
+
+./hack/build.sh
+./hack/linter.sh

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+golangci-lint cache clean
+golangci-lint run --max-same-issues 0

--- a/pkg/imgpkg/bundle/images_lock_test.go
+++ b/pkg/imgpkg/bundle/images_lock_test.go
@@ -44,9 +44,8 @@ func TestImagesLock_WriteToPath_WhenAnImageIsNotInBundleRepo_DoesNotUpdateTheIma
 		if reference.Identifier() != "sha256:8136ff3a64517457b91f86bf66b8ffe13b986aaf3511887eda107e59dcb8c632" &&
 			reference.Context().Name() == "some.place/repo" {
 			return regv1.Descriptor{}, fmt.Errorf("failed")
-		} else {
-			return regv1.Descriptor{}, nil
 		}
+		return regv1.Descriptor{}, nil
 	}
 	uiOutput, err := runWriteToPath(imageLock, fakeDescriptorRetrieval, bundleFolder)
 	if err != nil {
@@ -98,9 +97,8 @@ func TestImagesLock_WriteToPath_WhenAllImagesAreInBundleRepo_UpdatesTheImagesInI
 	fakeDescriptorRetrieval := func(reference regname.Reference) (regv1.Descriptor, error) {
 		if reference.Context().Name() == "some.place/repo" {
 			return regv1.Descriptor{}, nil
-		} else {
-			return regv1.Descriptor{}, fmt.Errorf("not found")
 		}
+		return regv1.Descriptor{}, fmt.Errorf("not found")
 	}
 	uiOutput, err := runWriteToPath(imageLock, fakeDescriptorRetrieval, bundleFolder)
 	if err != nil {

--- a/pkg/imgpkg/cmd/pull.go
+++ b/pkg/imgpkg/cmd/pull.go
@@ -112,7 +112,7 @@ func (o *PullOptions) validate() error {
 	presentInputParams := 0
 	for _, inputParam := range []string{o.LockInputFlags.LockFilePath, o.BundleFlags.Bundle, o.ImageFlags.Image} {
 		if len(inputParam) > 0 {
-			presentInputParams += 1
+			presentInputParams++
 		}
 	}
 	if presentInputParams > 1 {

--- a/pkg/imgpkg/image/prefixed_logger.go
+++ b/pkg/imgpkg/image/prefixed_logger.go
@@ -10,16 +10,16 @@ import (
 	"sync"
 )
 
-type kbldLogger struct {
+type KbldLogger struct {
 	writer     io.Writer
 	writerLock *sync.Mutex
 }
 
-func NewLogger(writer io.Writer) kbldLogger {
-	return kbldLogger{writer: writer, writerLock: &sync.Mutex{}}
+func NewLogger(writer io.Writer) KbldLogger {
+	return KbldLogger{writer: writer, writerLock: &sync.Mutex{}}
 }
 
-func (l kbldLogger) NewPrefixedWriter(prefix string) *LoggerPrefixWriter {
+func (l KbldLogger) NewPrefixedWriter(prefix string) *LoggerPrefixWriter {
 	return &LoggerPrefixWriter{prefix, l.writer, l.writerLock}
 }
 

--- a/pkg/imgpkg/image/resolved.go
+++ b/pkg/imgpkg/image/resolved.go
@@ -48,10 +48,10 @@ func (i ResolvedImage) URL() (string, error) {
 		return "", fmt.Errorf("Expected digest resolution to be consistent over two separate requests")
 	}
 
-	digestUrl, err := regname.NewDigest(tag.Repository.String() + "@" + imgDescriptor.Digest.String())
+	digestURL, err := regname.NewDigest(tag.Repository.String() + "@" + imgDescriptor.Digest.String())
 	if err != nil {
 		return "", err
 	}
 
-	return digestUrl.Name(), nil
+	return digestURL.Name(), nil
 }

--- a/pkg/imgpkg/imagetar/tar_file.go
+++ b/pkg/imgpkg/imagetar/tar_file.go
@@ -27,7 +27,7 @@ type tarFileChunk struct {
 var _ imagedesc.LayerContents = tarFileChunk{}
 
 type tarFileChunkReadCloser struct {
-	DebugId string
+	DebugID string
 	io.Reader
 	io.Closer
 }
@@ -64,7 +64,7 @@ func (f tarFile) openChunk(path string) (io.ReadCloser, error) {
 		}
 		if hdr.Name == path {
 			return tarFileChunkReadCloser{
-				DebugId: fmt.Sprintf("%s/%p", path, tf),
+				DebugID: fmt.Sprintf("%s/%p", path, tf),
 				Reader:  tf, Closer: file}, nil
 		}
 	}

--- a/pkg/imgpkg/imagetar/tar_writer.go
+++ b/pkg/imgpkg/imagetar/tar_writer.go
@@ -322,7 +322,7 @@ func (TarWriter) retry(fn func() error) error {
 type zeroReader struct{}
 
 func (r zeroReader) Read(p []byte) (n int, err error) {
-	for i, _ := range p {
+	for i := range p {
 		p[i] = 0
 	}
 	return len(p), nil

--- a/pkg/imgpkg/plainimage/plain_image.go
+++ b/pkg/imgpkg/plainimage/plain_image.go
@@ -53,28 +53,28 @@ func NewFetchedPlainImageWithTag(digestRef string, tag string,
 	}
 }
 
-func (o *PlainImage) Repo() string {
-	if o.parsedRef == nil {
+func (i *PlainImage) Repo() string {
+	if i.parsedRef == nil {
 		panic("Unexpected usage of Repo(); call Fetch before")
 	}
-	return o.parsedRef.Context().Name()
+	return i.parsedRef.Context().Name()
 }
 
-func (o *PlainImage) DigestRef() string {
-	if o.parsedRef == nil {
+func (i *PlainImage) DigestRef() string {
+	if i.parsedRef == nil {
 		panic("Unexpected usage of DigestRef(); call Fetch before")
 	}
-	if len(o.parsedDigest) == 0 {
+	if len(i.parsedDigest) == 0 {
 		panic("Unexpected usage of DigestRef(); call Fetch before")
 	}
-	return o.parsedRef.Context().Name() + "@" + o.parsedDigest
+	return i.parsedRef.Context().Name() + "@" + i.parsedDigest
 }
 
-func (o *PlainImage) Tag() string {
-	if o.parsedRef == nil {
+func (i *PlainImage) Tag() string {
+	if i.parsedRef == nil {
 		panic("Unexpected usage of Tag(); call Fetch before")
 	}
-	if tagRef, ok := o.parsedRef.(regname.Tag); ok {
+	if tagRef, ok := i.parsedRef.(regname.Tag); ok {
 		return tagRef.TagStr()
 	}
 	return "" // was a digest ref, so no tag

--- a/test/e2e/copy_test.go
+++ b/test/e2e/copy_test.go
@@ -226,7 +226,7 @@ images:
 		t.Fatalf("expected bundle tag to have tag '%v', was '%s'", bundleTag, relocatedBundleLock.Bundle.Tag)
 	}
 
-	if err := validateBundleLockApiVersionAndKind(relocatedBundleLock); err != nil {
+	if err := validateBundleLockAPIVersionAndKind(relocatedBundleLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -292,7 +292,7 @@ images:
 		t.Fatalf("expected lock output to contain relocated ref '%s', got '%s'", expectedRef, relocateImgLock.Images[0].Image)
 	}
 
-	if err := validateImageLockApiVersionAndKind(relocateImgLock); err != nil {
+	if err := validateImageLockAPIVersionAndKind(relocateImgLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -361,7 +361,7 @@ images:
 		t.Fatalf("expected lock output to contain tag '%s', got '%s'", trimmedTag, relocatedBundleLock.Bundle.Tag)
 	}
 
-	if err := validateBundleLockApiVersionAndKind(relocatedBundleLock); err != nil {
+	if err := validateBundleLockAPIVersionAndKind(relocatedBundleLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -450,7 +450,7 @@ func TestCopyImageToRepoDestinationAndOutputImageLockFile(t *testing.T) {
 			expectedRef, imgLock.Images[0].Image)
 	}
 
-	if err := validateImageLockApiVersionAndKind(imgLock); err != nil {
+	if err := validateImageLockAPIVersionAndKind(imgLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -551,7 +551,7 @@ images:
 			origBundleLock.Bundle.Tag, relocatedBundleLock.Bundle.Tag)
 	}
 
-	if err := validateBundleLockApiVersionAndKind(relocatedBundleLock); err != nil {
+	if err := validateBundleLockAPIVersionAndKind(relocatedBundleLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -636,7 +636,7 @@ images:
 		t.Fatalf("expected lock output to contain relocated ref '%s', got '%s'", expectedRef, imgLock.Images[0].Image)
 	}
 
-	if err := validateImageLockApiVersionAndKind(imgLock); err != nil {
+	if err := validateImageLockAPIVersionAndKind(imgLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -717,7 +717,7 @@ images:
 		t.Fatalf("expected bundle tag to have tag '%v', was '%s'", tag, bundleLock.Bundle.Tag)
 	}
 
-	if err := validateBundleLockApiVersionAndKind(bundleLock); err != nil {
+	if err := validateBundleLockAPIVersionAndKind(bundleLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -778,7 +778,7 @@ func TestCopyImageInputToTarFileAndToADifferentRepoCheckImageLockIsGenerated(t *
 		t.Fatalf("expected lock output to contain relocated ref '%s', got '%s'", imgLock.Images[0].Image, expectedRef)
 	}
 
-	if err := validateImageLockApiVersionAndKind(imgLock); err != nil {
+	if err := validateImageLockAPIVersionAndKind(imgLock); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -970,7 +970,7 @@ func validateImagesPresenceInRegistry(refs []string) error {
 	return nil
 }
 
-func validateBundleLockApiVersionAndKind(bLock lockconfig.BundleLock) error {
+func validateBundleLockAPIVersionAndKind(bLock lockconfig.BundleLock) error {
 	// Do not replace bundleLockKind or bundleLockAPIVersion with consts
 	// BundleLockKind or BundleLockAPIVersion.
 	// This is done to prevent updating the const.
@@ -986,7 +986,7 @@ func validateBundleLockApiVersionAndKind(bLock lockconfig.BundleLock) error {
 	return nil
 }
 
-func validateImageLockApiVersionAndKind(iLock lockconfig.ImagesLock) error {
+func validateImageLockAPIVersionAndKind(iLock lockconfig.ImagesLock) error {
 	// Do not replace imageLockKind or imagesLockAPIVersion with consts
 	// ImagesLockKind or ImagesLockAPIVersion.
 	// This is done to prevent updating the const.


### PR DESCRIPTION
This pull requests adds a linting tool ([golangci-lint](https://github.com/golangci/golangci-lint)) to `imgpkg`. `golangci-lint` allows users to add go linters to a project via a config file (`.golangci.yml`).

For this initial introduction of linting to the project, [`golint`](https://github.com/golang/lint#purpose) and [`go-header`](https://github.com/denis-tingaikin/go-header#go-header) are being added. `golint` helps to address styling issues associated with go projects. `go-header` checks if copyright headers are present for files in a project.

The introduction of `go-header` will help prevent checking in files with no license headers. All `golint` issues were fixed as part of introducing this change as well.

For now, linting is optional via a linter script under `/hack` but will eventually be added to CI. There is a blocker on adding it to CI that is being captured in a separate story.