### PR TITLE
Pull updates images lock files

### DIFF
--- a/pkg/imgpkg/bundle/bundle.go
+++ b/pkg/imgpkg/bundle/bundle.go
@@ -48,16 +48,11 @@ func (o *Bundle) Repo() string      { return o.plainImg.Repo() }
 func (o *Bundle) Tag() string       { return o.plainImg.Tag() }
 
 func (o *Bundle) Pull(outputPath string, ui goui.UI, pullNestedBundles bool) error {
-	_, err := o.checkedImage()
-	if err != nil {
-		return err
-	}
-
-	return o.pull(outputPath, ui, pullNestedBundles, "", map[string]bool{}, 0, o.Repo())
+	return o.pull(outputPath, ui, pullNestedBundles, "", map[string]bool{}, 0)
 }
 
 func (o *Bundle) pull(baseOutputPath string, ui goui.UI, pullNestedBundles bool, bundlePath string,
-	imagesProcessed map[string]bool, numSubBundles int, rootBundleRepo string) error {
+	imagesProcessed map[string]bool, numSubBundles int) error {
 	img, err := o.checkedImage()
 	if err != nil {
 		return err
@@ -79,8 +74,13 @@ func (o *Bundle) pull(baseOutputPath string, ui goui.UI, pullNestedBundles bool,
 		return err
 	}
 
+	localizedImagesLockToRepo, notLocalizedToBundle, err := NewImagesLock(imagesLock, o.imgRetriever, o.Repo()).LocalizeImagesLock()
+	if err != nil {
+		return err
+	}
+
 	if pullNestedBundles {
-		for _, image := range imagesLock.Images {
+		for _, image := range localizedImagesLockToRepo.Images {
 			if isBundle, alreadyProcessedImage := imagesProcessed[image.Image]; alreadyProcessedImage {
 				if isBundle {
 					goui.NewIndentingUI(ui).BeginLinef("Pulling nested bundle '%s'\n", image.Image)
@@ -109,8 +109,7 @@ func (o *Bundle) pull(baseOutputPath string, ui goui.UI, pullNestedBundles bool,
 			if err != nil {
 				return err
 			}
-			err = subBundle.pull(baseOutputPath, goui.NewIndentingUI(ui), pullNestedBundles,
-				o.subBundlePath(bundleDigest), imagesProcessed, numSubBundles, rootBundleRepo)
+			err = subBundle.pull(baseOutputPath, goui.NewIndentingUI(ui), pullNestedBundles, o.subBundlePath(bundleDigest), imagesProcessed, numSubBundles)
 			if err != nil {
 				return err
 			}
@@ -122,10 +121,16 @@ func (o *Bundle) pull(baseOutputPath string, ui goui.UI, pullNestedBundles bool,
 		imagesLockUI = goui.NewNoopUI()
 	}
 
-	err = NewImagesLock(imagesLock, o.imgRetriever, rootBundleRepo).WriteToPath(
-		filepath.Join(baseOutputPath, bundlePath), imagesLockUI)
-	if err != nil {
-		return fmt.Errorf("Rewriting image lock file: %s", err)
+	imagesLockUI.BeginLinef("\nLocating image lock file images...\n")
+	if notLocalizedToBundle {
+		imagesLockUI.BeginLinef("One or more images not found in bundle repo; skipping lock file update\n")
+	} else {
+		imagesLockUI.BeginLinef("The bundle repo (%s) is hosting every image specified in the bundle's Images Lock file (.imgpkg/images.yml)\n", o.Repo())
+
+		err := localizedImagesLockToRepo.WriteToPath(filepath.Join(baseOutputPath, bundlePath, ImgpkgDir, ImagesLockFile))
+		if err != nil {
+			return fmt.Errorf("Rewriting image lock file: %s", err)
+		}
 	}
 
 	return nil

--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -78,7 +78,7 @@ func (o *Bundle) ImagesLockLocalized() (lockconfig.ImagesLock, error) {
 		return lockconfig.ImagesLock{}, err
 	}
 
-	imagesLock, _, err = NewImagesLock(imagesLock, o.imgRetriever, o.Repo()).LocalizeImagesLock()
+	imagesLock, _, err = NewImagesLock(imagesLock, o.imgRetriever, o.Repo()).LocalizeImagesLock(true)
 	return imagesLock, err
 }
 

--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -78,7 +78,7 @@ func (o *Bundle) ImagesLockLocalized() (lockconfig.ImagesLock, error) {
 		return lockconfig.ImagesLock{}, err
 	}
 
-	imagesLock, _, err = NewImagesLock(imagesLock, o.imgRetriever, o.Repo()).LocalizeImagesLock(true)
+	imagesLock, _, err = NewImagesLock(imagesLock, o.imgRetriever, o.Repo()).LocalizeImagesLock()
 	return imagesLock, err
 }
 

--- a/pkg/imgpkg/bundle/images_lock.go
+++ b/pkg/imgpkg/bundle/images_lock.go
@@ -5,10 +5,8 @@ package bundle
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	"github.com/cppforlife/go-cli-ui/ui"
 	regname "github.com/google/go-containerregistry/pkg/name"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
@@ -55,26 +53,7 @@ func (o *ImagesLock) AddImageRef(ref lockconfig.ImageRef) {
 	o.imagesLock.AddImageRef(ref)
 }
 
-func (o *ImagesLock) WriteToPath(outputPath string, ui ui.UI) error {
-	imagesLockPath := filepath.Join(outputPath, ImgpkgDir, ImagesLockFile)
-
-	imagesLock, skipped, err := o.LocalizeImagesLock(true)
-	if err != nil {
-		return err
-	}
-
-	ui.BeginLinef("\nLocating image lock file images...\n")
-
-	if skipped {
-		ui.BeginLinef("One or more images not found in bundle repo; skipping lock file update\n")
-	} else {
-		ui.BeginLinef("The bundle repo (%s) is hosting every image specified in the bundle's Images Lock file (.imgpkg/images.yml)\n", o.relativeToRepo)
-	}
-
-	return imagesLock.WriteToPath(imagesLockPath)
-}
-
-func (o *ImagesLock) LocalizeImagesLock(checkRegistry bool) (lockconfig.ImagesLock, bool, error) {
+func (o *ImagesLock) LocalizeImagesLock() (lockconfig.ImagesLock, bool, error) {
 	var imageRefs []lockconfig.ImageRef
 	imagesLock := lockconfig.ImagesLock{
 		LockVersion: o.imagesLock.LockVersion,
@@ -85,24 +64,21 @@ func (o *ImagesLock) LocalizeImagesLock(checkRegistry bool) (lockconfig.ImagesLo
 		if err != nil {
 			return o.imagesLock, false, err
 		}
-		updatedImageRef := imageInBundleRepo
 
-		if checkRegistry {
-			updatedImageRef, err = o.checkImagesExist([]string{imageInBundleRepo, imgRef.Image})
-			if err != nil {
-				return o.imagesLock, false, err
-			}
+		foundImg, err := o.checkImagesExist([]string{imageInBundleRepo, imgRef.Image})
+		if err != nil {
+			return o.imagesLock, false, err
+		}
 
-			// If cannot find the image in the bundle repo, will not localize any image
-			// We assume that the bundle was not copied to the bundle location,
-			// so there we cannot localize any image
-			if updatedImageRef != imageInBundleRepo {
-				return o.imagesLock, true, nil
-			}
+		// If cannot find the image in the bundle repo, will not localize any image
+		// We assume that the bundle was not copied to the bundle location,
+		// so there we cannot localize any image
+		if foundImg != imageInBundleRepo {
+			return o.imagesLock, true, nil
 		}
 
 		imageRefs = append(imageRefs, lockconfig.ImageRef{
-			Image:       updatedImageRef,
+			Image:       foundImg,
 			Annotations: imgRef.Annotations,
 		})
 	}

--- a/pkg/imgpkg/bundle/images_lock_test.go
+++ b/pkg/imgpkg/bundle/images_lock_test.go
@@ -89,7 +89,7 @@ func TestImagesLock_WriteToPath(t *testing.T) {
 		}
 		uiOutput, err := runWriteToPath(imageLock, fakeDigestRetrieval, bundleFolder)
 		require.NoError(t, err)
-		require.Contains(t, uiOutput, "Updating all images in the ImagesLock file")
+		require.Contains(t, uiOutput, "hosting every image specified in the bundle's Images Lock file (.imgpkg/images.yml)")
 
 		resultImagesLock, err := lockconfig.NewImagesLockFromPath(filepath.Join(bundleFolder, ".imgpkg", "images.yml"))
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 		fakeImagesMetadata := &imagefakes.FakeImagesMetadata{}
 		subject := ctlbundle.NewImagesLock(imagesLock, fakeImagesMetadata, "some.repo.io/bundle")
 
-		newImagesLock, skipped, err := subject.LocalizeImagesLock()
+		newImagesLock, skipped, err := subject.LocalizeImagesLock(true)
 		require.NoError(t, err)
 		assert.False(t, skipped)
 
@@ -139,7 +139,7 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 		// Other calls will return the default empty Hash and nil error
 		fakeImagesMetadata.DigestReturnsOnCall(1, regv1.Hash{}, errors.New("not found"))
 
-		newImagesLock, skipped, err := subject.LocalizeImagesLock()
+		newImagesLock, skipped, err := subject.LocalizeImagesLock(true)
 		require.NoError(t, err)
 		assert.True(t, skipped)
 

--- a/pkg/imgpkg/bundle/images_lock_test.go
+++ b/pkg/imgpkg/bundle/images_lock_test.go
@@ -5,97 +5,19 @@ package bundle_test
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
-	regname "github.com/google/go-containerregistry/pkg/name"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	ctlbundle "github.com/k14s/imgpkg/pkg/imgpkg/bundle"
-	"github.com/k14s/imgpkg/pkg/imgpkg/bundle/bundlefakes"
 	"github.com/k14s/imgpkg/pkg/imgpkg/image/imagefakes"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
-	"github.com/k14s/imgpkg/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
-}
-
-func TestImagesLock_WriteToPath(t *testing.T) {
-	assets := helpers.Assets{T: t}
-	defer assets.CleanCreatedFolders()
-
-	t.Run("When an Image is not a Bundle, it does not update the ImagesLock file", func(t *testing.T) {
-		bundleFolder := assets.CreateTempFolder("no-update")
-		require.NoError(t, os.MkdirAll(filepath.Join(bundleFolder, ".imgpkg"), 0700))
-
-		imageLock := lockconfig.ImagesLock{
-			LockVersion: lockconfig.LockVersion{
-				APIVersion: lockconfig.ImagesLockAPIVersion,
-				Kind:       lockconfig.ImagesLockKind,
-			},
-			Images: []lockconfig.ImageRef{
-				{
-					Image: "some.place/repo@sha256:8136ff3a64517457b91f86bf66b8ffe13b986aaf3511887eda107e59dcb8c632",
-				},
-				{
-					Image: "gcr.io/cf-k8s-lifecycle-tooling-klt/nginx@sha256:f35b49b1d18e083235015fd4bbeeabf6a49d9dc1d3a1f84b7df3794798b70c13",
-				},
-			},
-		}
-		fakeDigestRetrieval := func(reference regname.Reference) (regv1.Hash, error) {
-			// Error out when checking for nginx image in the same repository as the bundle
-			if reference.Identifier() != "sha256:8136ff3a64517457b91f86bf66b8ffe13b986aaf3511887eda107e59dcb8c632" &&
-				reference.Context().Name() == "some.place/repo" {
-				return regv1.Hash{}, fmt.Errorf("failed")
-			}
-			return regv1.Hash{}, nil
-		}
-		uiOutput, err := runWriteToPath(imageLock, fakeDigestRetrieval, bundleFolder)
-		require.NoError(t, err)
-		assert.Contains(t, uiOutput, "skipping lock file update")
-
-		resultImagesLock, err := lockconfig.NewImagesLockFromPath(filepath.Join(bundleFolder, ".imgpkg", "images.yml"))
-		require.NoError(t, err)
-		require.Len(t, resultImagesLock.Images, 2)
-		assert.Equal(t, imageLock.Images[0].Image, resultImagesLock.Images[0].Image)
-		assert.Equal(t, imageLock.Images[1].Image, resultImagesLock.Images[1].Image)
-	})
-
-	t.Run("when all images are in the bundle repo, it updates the ImagesLock file", func(t *testing.T) {
-		bundleFolder := assets.CreateTempFolder("updated")
-		require.NoError(t, os.MkdirAll(filepath.Join(bundleFolder, ".imgpkg"), 0700))
-
-		imageLock := lockconfig.ImagesLock{
-			LockVersion: lockconfig.LockVersion{
-				APIVersion: lockconfig.ImagesLockAPIVersion,
-				Kind:       lockconfig.ImagesLockKind,
-			},
-			Images: []lockconfig.ImageRef{
-				{
-					Image: "some.other.place/repo@sha256:8136ff3a64517457b91f86bf66b8ffe13b986aaf3511887eda107e59dcb8c632",
-				},
-			},
-		}
-		fakeDigestRetrieval := func(reference regname.Reference) (regv1.Hash, error) {
-			if reference.Context().Name() != "some.place/repo" {
-				return regv1.Hash{}, fmt.Errorf("not found")
-			}
-			return regv1.Hash{}, nil
-		}
-		uiOutput, err := runWriteToPath(imageLock, fakeDigestRetrieval, bundleFolder)
-		require.NoError(t, err)
-		require.Contains(t, uiOutput, "hosting every image specified in the bundle's Images Lock file (.imgpkg/images.yml)")
-
-		resultImagesLock, err := lockconfig.NewImagesLockFromPath(filepath.Join(bundleFolder, ".imgpkg", "images.yml"))
-		require.NoError(t, err)
-		require.Len(t, resultImagesLock.Images, 1)
-		assert.NotEqual(t, imageLock.Images[0].Image, resultImagesLock.Images[0].Image)
-	})
 }
 
 func TestImagesLock_LocalizeImagesLock(t *testing.T) {
@@ -113,7 +35,7 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 		fakeImagesMetadata := &imagefakes.FakeImagesMetadata{}
 		subject := ctlbundle.NewImagesLock(imagesLock, fakeImagesMetadata, "some.repo.io/bundle")
 
-		newImagesLock, skipped, err := subject.LocalizeImagesLock(true)
+		newImagesLock, skipped, err := subject.LocalizeImagesLock()
 		require.NoError(t, err)
 		assert.False(t, skipped)
 
@@ -139,7 +61,7 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 		// Other calls will return the default empty Hash and nil error
 		fakeImagesMetadata.DigestReturnsOnCall(1, regv1.Hash{}, errors.New("not found"))
 
-		newImagesLock, skipped, err := subject.LocalizeImagesLock(true)
+		newImagesLock, skipped, err := subject.LocalizeImagesLock()
 		require.NoError(t, err)
 		assert.True(t, skipped)
 
@@ -251,16 +173,4 @@ func TestImagesLock_Merge(t *testing.T) {
 		assert.Equal(t, "some.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", imagesRefs[0].Image)
 		assert.Equal(t, map[string]string{"will be": "kept"}, imagesRefs[0].Annotations)
 	})
-}
-
-func runWriteToPath(imagesLock lockconfig.ImagesLock, fakeDigestHandler func(reference regname.Reference) (regv1.Hash, error), bundleFolder string) (string, error) {
-	fakeRegistry := &imagefakes.FakeImagesMetadata{}
-	fakeRegistry.DigestCalls(fakeDigestHandler)
-	uiOutput := ""
-	uiFake := &bundlefakes.FakeUI{}
-	uiFake.BeginLinefCalls(func(s string, i ...interface{}) {
-		uiOutput = fmt.Sprintf("%s%s", uiOutput, fmt.Sprintf(s, i...))
-	})
-	subject := ctlbundle.NewImagesLock(imagesLock, fakeRegistry, "some.place/repo")
-	return uiOutput, subject.WriteToPath(bundleFolder, uiFake)
 }

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/k14s/imgpkg/test/helpers"
@@ -38,6 +39,63 @@ images:
 
 	expectedImageRef := env.Image + imageDigestRef
 	env.Assert.AssertImagesLock(filepath.Join(pullDir, ".imgpkg", "images.yml"), []lockconfig.ImageRef{{Image: expectedImageRef}})
+}
+
+func TestPullImageLockRewriteBundleOfBundles(t *testing.T) {
+	env := helpers.BuildEnv(t)
+	logger := helpers.Logger{}
+	imgpkg := helpers.Imgpkg{t, helpers.Logger{}, env.ImgpkgPath}
+	defer env.Cleanup()
+
+	bundleDigestRef := ""
+	imageDigestRef := "@sha256:ebf526c198a14fa138634b9746c50ec38077ec9b3986227e79eb837d26f59dc6"
+	imageLockYAML := fmt.Sprintf(`---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock
+images:
+- image: hello-world%s
+`, imageDigestRef)
+
+	bundleDir := env.BundleFactory.CreateBundleDir(helpers.BundleYAML, imageLockYAML)
+	uniqueImageName := env.Image + fmt.Sprintf("%d", time.Now().Unix())
+	logger.Section("create inner bundle", func() {
+		out := imgpkg.Run([]string{"push", "--tty", "-b", uniqueImageName, "-f", bundleDir})
+		bundleDigestRef = helpers.ExtractDigest(t, out)
+	})
+
+	logger.Section("create new bundle with bundles", func() {
+		imagesLockYAML := fmt.Sprintf(`---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock
+images:
+- image: %s
+`, fmt.Sprintf("%s@%s", uniqueImageName, bundleDigestRef))
+		env.BundleFactory.AddFileToBundle(filepath.Join(".imgpkg", "images.yml"), imagesLockYAML)
+
+		outerBundleOut := imgpkg.Run([]string{"push", "--tty", "-b", uniqueImageName, "-f", bundleDir, "--experimental-recursive-bundle"})
+		outerBundleDigestRef := helpers.ExtractDigest(t, outerBundleOut)
+
+		imgpkg.Run([]string{"copy", "--experimental-recursive-bundle", "-b", uniqueImageName + "@" + outerBundleDigestRef, "--to-repo", uniqueImageName})
+
+		outDir := env.Assets.CreateTempFolder("bundle-annotation")
+
+		imgpkg.Run([]string{"pull", "--recursive", "-b", uniqueImageName, "-o", outDir})
+
+		subBundleDirectoryPath := strings.ReplaceAll(bundleDigestRef, "sha256:", "sha256-")
+		assert.DirExists(t, filepath.Join(outDir, ".imgpkg", "bundles", subBundleDirectoryPath))
+		assert.FileExists(t, filepath.Join(outDir, ".imgpkg", "bundles", subBundleDirectoryPath, ".imgpkg", "images.yml"))
+		assert.FileExists(t, filepath.Join(outDir, ".imgpkg", "bundles", subBundleDirectoryPath, ".imgpkg", "bundle.yml"))
+
+		innerBundleImagesYmlContent, err := os.ReadFile(filepath.Join(outDir, ".imgpkg", "bundles", subBundleDirectoryPath, ".imgpkg", "images.yml"))
+		assert.NoError(t, err)
+
+		assert.Regexp(t, fmt.Sprintf(`---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- image: %s
+kind: ImagesLock
+`, uniqueImageName+imageDigestRef), string(innerBundleImagesYmlContent))
+	})
 }
 
 func TestPullBundleOfBundles(t *testing.T) {
@@ -75,6 +133,6 @@ images:
 
 		innerBundleImagesYmlContent, err := os.ReadFile(filepath.Join(outDir, ".imgpkg", "bundles", subBundleDirectoryPath, ".imgpkg", "images.yml"))
 		assert.NoError(t, err)
-		assert.Equal(t, string(innerBundleImagesYmlContent), helpers.ImagesYAML)
+		assert.Equal(t, helpers.ImagesYAML, string(innerBundleImagesYmlContent))
 	})
 }

--- a/test/helpers/fake_registry.go
+++ b/test/helpers/fake_registry.go
@@ -88,7 +88,7 @@ func (r *FakeTestRegistryBuilder) WithBundleFromPath(bundleName string, path str
 	digest, err := bundle.Digest()
 	assert.NoError(r.t, err)
 
-	return BundleInfo{r, bundleName, path, digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
+	return BundleInfo{r, bundle, bundleName, path, digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
 }
 
 func (r *FakeTestRegistryBuilder) WithRandomBundle(bundleName string) BundleInfo {
@@ -105,7 +105,7 @@ func (r *FakeTestRegistryBuilder) WithRandomBundle(bundleName string) BundleInfo
 	digest, err := bundle.Digest()
 	assert.NoError(r.t, err)
 
-	return BundleInfo{r, bundleName, "", digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
+	return BundleInfo{r, bundle, bundleName, "", digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
 }
 
 func (r *FakeTestRegistryBuilder) WithImageFromPath(imageNameFromTest string, path string, labels map[string]string) *ImageOrImageIndexWithTarPath {
@@ -140,7 +140,7 @@ func (r *FakeTestRegistryBuilder) CopyImage(img ImageOrImageIndexWithTarPath, to
 func (r *FakeTestRegistryBuilder) CopyBundleImage(bundleInfo BundleInfo, to string) BundleInfo {
 	newBundle := *r.images[bundleInfo.BundleName]
 	r.updateState(to, newBundle.Image, nil, "")
-	return BundleInfo{r, to, "", bundleInfo.Digest, bundleInfo.RefDigest}
+	return BundleInfo{r, newBundle.Image, to, "", bundleInfo.Digest, bundleInfo.RefDigest}
 }
 
 func (r *FakeTestRegistryBuilder) WithARandomImageIndex(imageName string) {
@@ -208,6 +208,7 @@ func (r *FakeTestRegistryBuilder) updateState(imageName string, image v1.Image, 
 
 type BundleInfo struct {
 	r          *FakeTestRegistryBuilder
+	Image      v1.Image
 	BundleName string
 	BundlePath string
 	Digest     string


### PR DESCRIPTION
This is a draft (so so draft it could be a beer 🍺) PR to increase visibility on changes being made. As well as keep track of any design decisions being made as work is iterated on.

- 'first attempt' implementation on updating bundle / nested bundle image lock files. 
-- still requires refactoring on how it was implemented. but it makes the tests go green.
- Need to determine whether when determining if a nested bundle has been relocated, the nested bundle repo is used, or whether the root bundle repo is used (or both?)
- doesn't implement the UI portion of the story yet...