### PR TITLE
Use ggcr library to write images with non-distributable layers

### DIFF
--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
-
 	regname "github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
 	ctlimgset "github.com/k14s/imgpkg/pkg/imgpkg/imageset"
@@ -77,9 +75,12 @@ func (o *CopyOptions) Run() error {
 	logger := ctlimg.NewLogger(os.Stderr)
 	prefixedLogger := logger.NewPrefixedWriter("copy | ")
 
-	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts(), imagelayers.NewImageLayerWriterCheck(o.IncludeNonDistributableFlag.IncludeNonDistributable))
+	opts := o.RegistryFlags.AsRegistryOpts()
+	opts.IncludeNonDistributableLayers = o.IncludeNonDistributableFlag.IncludeNonDistributable
+
+	registry, err := ctlimg.NewRegistry(opts)
 	if err != nil {
-		return fmt.Errorf("Unable to create a registry with the options %v: %v", o.RegistryFlags.AsRegistryOpts(), err)
+		return fmt.Errorf("Unable to create a registry with the options %v: %v", opts, err)
 	}
 
 	switch {

--- a/pkg/imgpkg/cmd/copy_repo_src.go
+++ b/pkg/imgpkg/cmd/copy_repo_src.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
+	"github.com/k14s/imgpkg/pkg/imgpkg/imagetar"
 
 	regname "github.com/google/go-containerregistry/pkg/name"
 	ctlbundle "github.com/k14s/imgpkg/pkg/imgpkg/bundle"
@@ -18,15 +18,15 @@ import (
 )
 
 type CopyRepoSrc struct {
-	ImageFlags                  ImageFlags
-	BundleFlags                 BundleFlags
-	LockInputFlags              LockInputFlags
-	IncludeNonDistributableFlag IncludeNonDistributableFlag
-	ExperimentalFlags           ExperimentalFlags
-	logger                      *ctlimg.LoggerPrefixWriter
-	imageSet                    ctlimgset.ImageSet
-	tarImageSet                 ctlimgset.TarImageSet
-	registry                    ctlimgset.ImagesReaderWriter
+	ImageFlags              ImageFlags
+	BundleFlags             BundleFlags
+	LockInputFlags          LockInputFlags
+	IncludeNonDistributable bool
+	ExperimentalFlags       ExperimentalFlags
+	logger                  *ctlimg.LoggerPrefixWriter
+	imageSet                ctlimgset.ImageSet
+	tarImageSet             ctlimgset.TarImageSet
+	registry                ctlimgset.ImagesReaderWriter
 }
 
 func (o CopyRepoSrc) CopyToTar(dstPath string) error {
@@ -35,12 +35,12 @@ func (o CopyRepoSrc) CopyToTar(dstPath string) error {
 		return err
 	}
 
-	ids, err := o.tarImageSet.Export(unprocessedImageRefs, dstPath, o.registry, imagelayers.NewImageLayerWriterCheck(o.IncludeNonDistributableFlag.IncludeNonDistributable))
+	ids, err := o.tarImageSet.Export(unprocessedImageRefs, dstPath, o.registry, imagetar.NewImageLayerWriterCheck(o.IncludeNonDistributable))
 	if err != nil {
 		return err
 	}
 
-	informUserToUseTheNonDistributableFlagWithDescriptors(o.logger, o.IncludeNonDistributableFlag.IncludeNonDistributable, imageRefDescriptorsMediaTypes(ids))
+	informUserToUseTheNonDistributableFlagWithDescriptors(o.logger, o.IncludeNonDistributable, imageRefDescriptorsMediaTypes(ids))
 
 	return nil
 }
@@ -61,7 +61,7 @@ func (o CopyRepoSrc) CopyToRepo(repo string) (*ctlimgset.ProcessedImages, error)
 		return nil, err
 	}
 
-	informUserToUseTheNonDistributableFlagWithDescriptors(o.logger, o.IncludeNonDistributableFlag.IncludeNonDistributable, imageRefDescriptorsMediaTypes(ids))
+	informUserToUseTheNonDistributableFlagWithDescriptors(o.logger, o.IncludeNonDistributable, imageRefDescriptorsMediaTypes(ids))
 
 	return processedImages, nil
 }

--- a/pkg/imgpkg/cmd/copy_repo_src_test.go
+++ b/pkg/imgpkg/cmd/copy_repo_src_test.go
@@ -143,9 +143,7 @@ func TestToTarBundleContainingNonDistributableLayers(t *testing.T) {
 
 	t.Run("When Include-non-distributable flag is provided the tarball should contain every layer", func(t *testing.T) {
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -159,9 +157,7 @@ func TestToTarBundleContainingNonDistributableLayers(t *testing.T) {
 	t.Run("When Include-non-distributable flag is provided a warning message should not be printed", func(t *testing.T) {
 		stdOut.Reset()
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -228,9 +224,7 @@ func TestToTarImage(t *testing.T) {
 
 	t.Run("When Include-non-distributable flag is provided the tarball should contain every layer", func(t *testing.T) {
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -244,9 +238,7 @@ func TestToTarImage(t *testing.T) {
 	t.Run("When Include-non-distributable flag is provided a warning message should be printed", func(t *testing.T) {
 		stdOut.Reset()
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -283,9 +275,7 @@ func TestToTarImageContainingNonDistributableLayers(t *testing.T) {
 	})
 	t.Run("When Include-non-distributable flag is provided the tarball should contain every layer", func(t *testing.T) {
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -324,9 +314,7 @@ func TestToTarImageIndex(t *testing.T) {
 	})
 	t.Run("When Include-non-distributable flag is provided the tarball should contain every layer", func(t *testing.T) {
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -341,9 +329,7 @@ func TestToTarImageIndex(t *testing.T) {
 	t.Run("When Include-non-distributable flag is provided a warning message should be printed", func(t *testing.T) {
 		stdOut.Reset()
 		subject := subject
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		imageTarPath := filepath.Join(os.TempDir(), "bundle.tar")
 		defer os.Remove(imageTarPath)
@@ -565,9 +551,7 @@ func TestToRepoImage(t *testing.T) {
 		stdOut.Reset()
 		subject := subject
 		subject.registry = fakeRegistry.Build()
-		subject.IncludeNonDistributableFlag = IncludeNonDistributableFlag{
-			IncludeNonDistributable: true,
-		}
+		subject.IncludeNonDistributable = true
 
 		_, err := subject.CopyToRepo(fakeRegistry.ReferenceOnTestServer("fakeregistry/some-repo"))
 		if err != nil {

--- a/pkg/imgpkg/cmd/pull.go
+++ b/pkg/imgpkg/cmd/pull.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/k14s/imgpkg/pkg/imgpkg/plainimage"
 	"github.com/spf13/cobra"
@@ -61,7 +60,7 @@ func (o *PullOptions) Run() error {
 		return err
 	}
 
-	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts(), imagelayers.ImageLayerWriterFilter{})
+	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts())
 	if err != nil {
 		return fmt.Errorf("Unable to create a registry with the options %v: %v", o.RegistryFlags.AsRegistryOpts(), err)
 	}

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -10,7 +10,6 @@ import (
 	regname "github.com/google/go-containerregistry/pkg/name"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/k14s/imgpkg/pkg/imgpkg/plainimage"
 	"github.com/spf13/cobra"
@@ -53,7 +52,7 @@ func NewPushCmd(o *PushOptions) *cobra.Command {
 }
 
 func (o *PushOptions) Run() error {
-	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts(), imagelayers.ImageLayerWriterFilter{})
+	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts())
 	if err != nil {
 		return fmt.Errorf("Unable to create a registry with provided options: %v", err)
 	}

--- a/pkg/imgpkg/cmd/tag_list.go
+++ b/pkg/imgpkg/cmd/tag_list.go
@@ -10,7 +10,6 @@ import (
 	uitable "github.com/cppforlife/go-cli-ui/ui/table"
 	regname "github.com/google/go-containerregistry/pkg/name"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +41,7 @@ func NewTagListCmd(o *TagListOptions) *cobra.Command {
 }
 
 func (o *TagListOptions) Run() error {
-	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts(), imagelayers.ImageLayerWriterFilter{})
+	registry, err := ctlimg.NewRegistry(o.RegistryFlags.AsRegistryOpts())
 	if err != nil {
 		return fmt.Errorf("Unable to create a registry with the options %v: %v", o.RegistryFlags.AsRegistryOpts(), err)
 	}

--- a/pkg/imgpkg/image/registry.go
+++ b/pkg/imgpkg/image/registry.go
@@ -33,9 +33,10 @@ const (
 )
 
 type RegistryOpts struct {
-	CACertPaths                   []string
-	VerifyCerts                   bool
-	Insecure                      bool
+	CACertPaths []string
+	VerifyCerts bool
+	Insecure    bool
+
 	IncludeNonDistributableLayers bool
 
 	Username string

--- a/pkg/imgpkg/imageset/tar_image_set.go
+++ b/pkg/imgpkg/imageset/tar_image_set.go
@@ -8,11 +8,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
-
 	regname "github.com/google/go-containerregistry/pkg/name"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
+	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagetar"
 )
 
@@ -26,7 +24,7 @@ func NewTarImageSet(imageSet ImageSet, concurrency int, logger *ctlimg.LoggerPre
 	return TarImageSet{imageSet, concurrency, logger}
 }
 
-func (o TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath string, registry ImagesReaderWriter, imageLayerWriterCheck imagelayers.ImageLayerWriterFilter) (*imagedesc.ImageRefDescriptors, error) {
+func (o TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath string, registry ImagesReaderWriter, imageLayerWriterCheck imagetar.ImageLayerWriterFilter) (*imagedesc.ImageRefDescriptors, error) {
 	ids, err := o.imageSet.Export(foundImages, registry)
 	if err != nil {
 		return nil, err

--- a/pkg/imgpkg/imagetar/non_distributable_layers.go
+++ b/pkg/imgpkg/imagetar/non_distributable_layers.go
@@ -1,7 +1,7 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package imagelayers
+package imagetar
 
 import (
 	regv1 "github.com/google/go-containerregistry/pkg/v1"

--- a/pkg/imgpkg/imagetar/non_distributable_layers_test.go
+++ b/pkg/imgpkg/imagetar/non_distributable_layers_test.go
@@ -1,11 +1,12 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package imagelayers
+package imagetar
 
 import (
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
 	"testing"
+
+	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
 )
 
 func TestIncludesNonDistributableLayerWhenFlagIsProvided(t *testing.T) {

--- a/pkg/imgpkg/imagetar/tar_writer.go
+++ b/pkg/imgpkg/imagetar/tar_writer.go
@@ -12,8 +12,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
-
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
 	"github.com/k14s/imgpkg/pkg/imgpkg/util"
@@ -37,10 +35,10 @@ type TarWriter struct {
 
 	opts                  TarWriterOpts
 	logger                Logger
-	imageLayerWriterCheck imagelayers.ImageLayerWriterFilter
+	imageLayerWriterCheck ImageLayerWriterFilter
 }
 
-func NewTarWriter(ids *imagedesc.ImageRefDescriptors, dstOpener func() (io.WriteCloser, error), opts TarWriterOpts, logger Logger, imageLayerWriterCheck imagelayers.ImageLayerWriterFilter) *TarWriter {
+func NewTarWriter(ids *imagedesc.ImageRefDescriptors, dstOpener func() (io.WriteCloser, error), opts TarWriterOpts, logger Logger, imageLayerWriterCheck ImageLayerWriterFilter) *TarWriter {
 	return &TarWriter{ids: ids, dstOpener: dstOpener, opts: opts, logger: logger, imageLayerWriterCheck: imageLayerWriterCheck}
 }
 

--- a/test/helpers/fake_registry.go
+++ b/test/helpers/fake_registry.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
 	"github.com/k14s/imgpkg/pkg/imgpkg/image"
-	"github.com/k14s/imgpkg/pkg/imgpkg/imagelayers"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +66,7 @@ func (r *FakeTestRegistryBuilder) Build() image.Registry {
 
 	}
 
-	reg, err := image.NewRegistry(image.RegistryOpts{}, imagelayers.NewImageLayerWriterCheck(false))
+	reg, err := image.NewRegistry(image.RegistryOpts{})
 	assert.NoError(r.t, err)
 	return reg
 }


### PR DESCRIPTION
There has been an upstream change made to ggcr that allows configuring `Write` and `MultiWrite` to write layers that have a media type of 'non-distributable'.

This PR removes the previous approach of handling writing non-dist layers, and instead delegates to the library.

Another nice benefits (apart from less code) is potential performance improvement due to de-duping layer logic now also applied to non-dist layers