### PR TITLE
Bug fix bundle copy from bundle lock

### DIFF
--- a/pkg/imgpkg/cmd/copy_repo_src.go
+++ b/pkg/imgpkg/cmd/copy_repo_src.go
@@ -91,7 +91,7 @@ func (o CopyRepoSrc) getSourceImages() (*ctlimgset.UnprocessedImageRefs, error) 
 			}
 
 			for _, img := range imageRefs {
-				unprocessedImageRefs.Add(ctlimgset.UnprocessedImageRef{DigestRef: img.Image})
+				unprocessedImageRefs.Add(ctlimgset.UnprocessedImageRef{DigestRef: img.PrimaryLocation()})
 			}
 
 			unprocessedImageRefs.Add(ctlimgset.UnprocessedImageRef{

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -72,10 +72,10 @@ images:
 `, fmt.Sprintf("%s@%s", uniqueImageName, bundleDigestRef))
 		env.BundleFactory.AddFileToBundle(filepath.Join(".imgpkg", "images.yml"), imagesLockYAML)
 
-		outerBundleOut := imgpkg.Run([]string{"push", "--tty", "-b", uniqueImageName, "-f", bundleDir, "--experimental-recursive-bundle"})
+		outerBundleOut := imgpkg.Run([]string{"push", "--tty", "-b", uniqueImageName, "-f", bundleDir})
 		outerBundleDigestRef := helpers.ExtractDigest(t, outerBundleOut)
 
-		imgpkg.Run([]string{"copy", "--experimental-recursive-bundle", "-b", uniqueImageName + "@" + outerBundleDigestRef, "--to-repo", uniqueImageName})
+		imgpkg.Run([]string{"copy", "-b", uniqueImageName + "@" + outerBundleDigestRef, "--to-repo", uniqueImageName})
 
 		outDir := env.Assets.CreateTempFolder("bundle-annotation")
 


### PR DESCRIPTION
 When copying bundles, via the `BundleLock` file, and the images referenced are co-located with the 'source' bundle, then use the image reference that is co-located with the source bundle. Otherwise, this may cause issues during an airgapped environment.

Also fix a failing e2e test. The experimental flag was removed, however there is a test that is using the now removed flag.