### PR TITLE
Automate creating a GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: goreleaser
 on:
   pull_request:
   push:
+    tags:
+      - 'v*'
 
 jobs:
   goreleaser:
@@ -17,13 +19,80 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16.0
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          version: ${{ github.event.release.tag_name }}
-          args: release --rm-dist
+          version: 0.162.0
+          args: release --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        uses: actions/github-script@v4
+        id: get-checksums-from-draft-release
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            var crypto = require('crypto');
+            const { owner, repo } = context.repo;
+
+            // https://docs.github.com/en/rest/reference/repos#list-releases
+            // https://octokit.github.io/rest.js/v18#repos-list-releases
+            var releases = await github.repos.listReleases({
+              owner: owner,
+              repo: repo
+            });
+
+            var crypto = require('crypto')
+            var fs = require('fs')
+            const url = require('url');
+            const https = require('https');
+
+            checksums = {}
+            for (const r of releases["data"]) {
+              if (r.draft && `refs/tags/${r.tag_name}` == "${{ github.ref }}") {
+                for (const asset of r.assets) {
+                  var release_asset = await github.repos.getReleaseAsset({ headers: {accept: `application/octet-stream`}, accept: `application/octet-stream`, owner: owner, repo: repo, asset_id: asset.id });
+                  const hash = crypto.createHash('sha256');
+
+                  let http_promise = new Promise((resolve, reject) => {
+                    https.get(release_asset.url, (stream) => {
+                      stream.on('data', function (data) {
+                        hash.update(data);
+                      });
+                      stream.on('end', function () {
+                        checksums[asset.name]= hash.digest('hex');
+                        resolve(`${asset.name}`);
+                      });
+                    });
+                  });
+                  await http_promise;
+                }
+              }
+            }
+            console.log(checksums)
+
+            return `${checksums['imgpkg-darwin-amd64']}  ./imgpkg-darwin-amd64
+            ${checksums['imgpkg-linux-amd64']}  ./imgpkg-linux-amd64
+            ${checksums['imgpkg-windows-amd64.exe']}  ./imgpkg-windows-amd64.exe`
+
+      -
+        name: verify uploaded artifacts
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          set -e -x
+          VERSION=`echo ${{ github.ref }}  | grep -Eo '[0-9].*'`
+
+          ./hack/build-binaries.sh "$VERSION" > ./go-checksums
+          cat ./go-checksums
+          diff ./go-checksums <(cat <<EOF
+          ${{steps.get-checksums-from-draft-release.outputs.result}}
+          EOF
+          )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          version: ${{ github.event.release.tag_name }}
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.16.0
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: 0.162.0

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tmp
 .DS_Store
 /test/e2e/assets/simple-app/empty-dir
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ snapshot:
 release:
   # Repo in which the release will be created.
   github:
-    owner: DennisDenuto
+    owner: vmware-tanzu
     name: carvel-imgpkg
 
   # If set to true, will not auto-publish the release.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,83 @@
+# This is an example .goreleaser.yml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+    main: ./cmd/imgpkg
+    binary: imgpkg-{{ .Os }}-{{ .Arch }}
+
+    # not sure if the ldflags buildid is needed anymore. check https://github.com/golang/go/issues/16860
+    flags:
+      - -trimpath
+    ldflags:
+      - -buildid=
+
+    # is mod_timestamp needed?
+    # mod_timestamp: '{{ .CommitTimestamp }}'
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+  disable: false
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  # Note: it can only be one: either github, gitlab or gitea
+  github:
+    owner: DennisDenuto
+    name: carvel-imgpkg
+
+  # If set to true, will not auto-publish the release.
+  # Default is false.
+  draft: true
+
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  prerelease: auto
+
+  # You can change the name of the release.
+  # Default is `{{.Tag}}`
+  name_template: "{{.Tag}}"
+
+  # You can disable this pipe in order to not upload any artifacts.
+  # Defaults to false.
+  disable: false
+
+changelog:
+  # Set it to true if you wish to skip the changelog generation.
+  # This may result in an empty release notes on GitHub/GitLab/Gitea.
+  skip: false
+
+  # Sorts the changelog by the commit's messages.
+  # Could either be asc, desc or empty
+  # Default is empty
+  sort: asc
+
+  filters:
+    # Commit messages matching the regexp listed here will be removed from
+    # the changelog
+    # Default is empty
+    exclude:
+      - '^docs:'
+      - typo
+      - (?i)foo

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,15 +15,13 @@ builds:
     main: ./cmd/imgpkg
     binary: imgpkg-{{ .Os }}-{{ .Arch }}
 
-    # not sure if the ldflags buildid is needed anymore. check https://github.com/golang/go/issues/16860
     flags:
       - -trimpath
-    ldflags:
-      - -X "github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}"
-      - -buildid=
 
-    # is mod_timestamp needed?
-    # mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags:
+      - -buildid=
+      - -X github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}
+
 archives:
   - format: binary
     name_template: "{{ .Binary }}"
@@ -40,14 +38,11 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 release:
   # Repo in which the release will be created.
-  # Default is extracted from the origin remote URL or empty if its private hosted.
-  # Note: it can only be one: either github, gitlab or gitea
   github:
     owner: DennisDenuto
     name: carvel-imgpkg
 
   # If set to true, will not auto-publish the release.
-  # Default is false.
   draft: true
 
   # If set to auto, will mark the release as not ready for production
@@ -56,8 +51,7 @@ release:
   # Default is false.
   prerelease: auto
 
-  # You can change the name of the release.
-  # Default is `{{.Tag}}`
+  # use to change the name of the release.
   name_template: "{{.Tag}}"
 
   # You can disable this pipe in order to not upload any artifacts.
@@ -81,4 +75,3 @@ changelog:
     exclude:
       - '^docs:'
       - typo
-      - (?i)foo

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -X "github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}"
       - -buildid=
 
     # is mod_timestamp needed?

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -2,14 +2,19 @@
 
 set -e -x -u
 
-./hack/build.sh
+VERSION="$1"
+
+go fmt ./cmd/... ./pkg/... ./test/...
+go mod vendor
+go mod tidy
 
 # makes builds reproducible
 export CGO_ENABLED=0
-repro_flags="-ldflags=-buildid= -trimpath"
+LDFLAGS="-X github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version=$VERSION -buildid="
 
-GOOS=darwin GOARCH=amd64 go build $repro_flags -o imgpkg-darwin-amd64 ./cmd/imgpkg/...
-GOOS=linux GOARCH=amd64 go build $repro_flags -o imgpkg-linux-amd64 ./cmd/imgpkg/...
-GOOS=windows GOARCH=amd64 go build $repro_flags -o imgpkg-windows-amd64.exe ./cmd/imgpkg/...
 
-shasum -a 256 ./imgpkg-*-amd64*
+GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -trimpath -o imgpkg-darwin-amd64 ./cmd/imgpkg/...
+GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -trimpath -o imgpkg-linux-amd64 ./cmd/imgpkg/...
+GOOS=windows GOARCH=amd64 go build -ldflags="$LDFLAGS" -trimpath -o imgpkg-windows-amd64.exe ./cmd/imgpkg/...
+
+shasum -a 256 ./imgpkg-darwin-amd64 ./imgpkg-linux-amd64 ./imgpkg-windows-amd64.exe

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -2,7 +2,8 @@
 
 set -e -x -u
 
-VERSION="$1"
+LATEST_GIT_TAG=$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+')
+VERSION="${1:-$LATEST_GIT_TAG}"
 
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,16 +2,18 @@
 
 set -e -x -u
 
+VERSION="$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' || echo 'develop')"
+
 # makes builds reproducible
 export CGO_ENABLED=0
-repro_flags="-ldflags=-buildid= -trimpath"
+LDFLAGS="-X github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version=$VERSION -buildid="
 
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor
 go mod tidy
 
 # export GOOS=linux GOARCH=amd64
-go build $repro_flags -o imgpkg ./cmd/imgpkg/...
+go build -ldflags="$LDFLAGS" -trimpath -o imgpkg ./cmd/imgpkg/...
 ./imgpkg version
 
 echo "Success"

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,6 +2,16 @@
 
 set -e -x -u
 
+# docker run --rm --privileged \
+#  -v $PWD:/go/src/github.com/user/repo \
+#  -v /var/run/docker.sock:/var/run/docker.sock \
+#  -w /go/src/github.com/user/repo \
+#  -e GITHUB_TOKEN \
+#  -e DOCKER_USERNAME \
+#  -e DOCKER_PASSWORD \
+#  -e DOCKER_REGISTRY \
+#  goreleaser/goreleaser release
+
 # makes builds reproducible
 export CGO_ENABLED=0
 repro_flags="-ldflags=-buildid= -trimpath"

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,11 +2,9 @@
 
 set -e -x -u
 
-VERSION="$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' || echo 'develop')"
-
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version=$VERSION -buildid="
+LDFLAGS="-buildid="
 
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,16 +2,6 @@
 
 set -e -x -u
 
-# docker run --rm --privileged \
-#  -v $PWD:/go/src/github.com/user/repo \
-#  -v /var/run/docker.sock:/var/run/docker.sock \
-#  -w /go/src/github.com/user/repo \
-#  -e GITHUB_TOKEN \
-#  -e DOCKER_USERNAME \
-#  -e DOCKER_PASSWORD \
-#  -e DOCKER_REGISTRY \
-#  goreleaser/goreleaser release
-
 # makes builds reproducible
 export CGO_ENABLED=0
 repro_flags="-ldflags=-buildid= -trimpath"

--- a/pkg/imgpkg/cmd/version.go
+++ b/pkg/imgpkg/cmd/version.go
@@ -10,9 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	Version = "0.8.0"
-)
+var Version = ""
 
 type VersionOptions struct {
 	ui ui.UI

--- a/pkg/imgpkg/cmd/version.go
+++ b/pkg/imgpkg/cmd/version.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = ""
+var Version = "develop"
 
 type VersionOptions struct {
 	ui ui.UI


### PR DESCRIPTION
Use [goreleaser](https://goreleaser.com/) to create a GH release

Use [github-release-notes](github.com/buchanae/github-release-notes) to generate release notes

TODO:

- [x] add goreleaser github action (trigger a release when a tag is pushed)
- [x] Upload binaries (instead of uploading the tar.gz files)
- [x] Checksum file should include checksums for binaries (not the tar.gz files)
- [x] ensure that binary files are 'reproducible builds' (goreleaser builds the same sha as ./hack/build-binaries.sh)
- [x] Use ld flags to update the version variable (from a tag) when publishing a release
~~- [x] make a carvel member generate a one-time token to provide to the goreleaser github action~~ <- No need. read: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
- [x] Release notes should contain checksum (not just as an attached file) <- leave this as a manual step for now
- [x] add a post release step in the GH action, that verifies the SHA of the binaries uploaded via gorelease match up with the SHAs built by a native go binary
- [x] change `hack/build-binary.sh` to generate the version based on the tag the commit is on. since version is now a build flag.
- [x] check if we can restrict network of the github action (only allow requests to github.com)??
- [x] Change github owner (in the .goreleaser.yml file) from DennisDenuto -> vmware-tanzu
~~- [ ] hack/build scripts can use goreleaser to generate binary files~~
- [ ] automate homebrew update https://goreleaser.com/customization/homebrew/
- [ ] automate creating a snapshot of OSM latest
~~- [ ] copy the gorelease GH action into our repo. and in our gh.yml point to the digest of the relocated image~~
- [ ] Update release documentation
  - [ ] review draft release notes and add the checksum to the release notes (goreleaser attaches the file but doesn't add it to the release notes section) 
