### PR TITLE
Bug Fix - stop crashing when copying a tar with an ImageIndex

### DIFF
--- a/test/e2e/assets/bundle/.imgpkg/bundle.yml
+++ b/test/e2e/assets/bundle/.imgpkg/bundle.yml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: basic
+authors:
+- name: Carvel Team
+  email: carvel@vmware.com
+websites:
+- url: carvel.dev/imgpkg

--- a/test/e2e/assets/bundle/.imgpkg/images.yml.template
+++ b/test/e2e/assets/bundle/.imgpkg/images.yml.template
@@ -1,0 +1,6 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock
+images:
+- image: library/image_with_config@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
+  annotations:
+    kbld.carvel.dev/id: docker.io/library/image_with_config

--- a/test/e2e/assets/bundle/config.yml
+++ b/test/e2e/assets/bundle/config.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: simple-app
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    simple-app: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: simple-app
+spec:
+  selector:
+    matchLabels:
+      simple-app: ""
+  template:
+    metadata:
+      labels:
+        simple-app: ""
+    spec:
+      containers:
+      - name: simple-app
+        image: docker.io/dkalinin/k8s-simple-app
+        env:
+          - name: HELLO_MSG
+            value: stranger

--- a/test/e2e/copy_from_tar_test.go
+++ b/test/e2e/copy_from_tar_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
+	"github.com/k14s/imgpkg/test/helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyTarSrc(t *testing.T) {
+	t.Run("When a tar contains an ImageIndex", func(t *testing.T) {
+		env := helpers.BuildEnv(t)
+		imgpkg := helpers.Imgpkg{t, helpers.Logger{}, env.ImgpkgPath}
+		defer env.Cleanup()
+
+		fakeRegistry := helpers.NewFakeRegistry(t)
+		defer fakeRegistry.CleanUp()
+		imageIndex := fakeRegistry.WithARandomImageIndex("repo/imageindex")
+		bundleInfo := fakeRegistry.WithBundleFromPath("repo/bundle", "assets/bundle").WithImageRefs([]lockconfig.ImageRef{
+			{Image: imageIndex.RefDigest},
+		})
+
+		fakeRegistry.Build()
+
+		tempBundleTarDir := env.Assets.CreateTempFolder("bundle-tar")
+		tempBundleTarFile := filepath.Join(tempBundleTarDir, "bundle-tar.tgz")
+		imgpkg.Run([]string{"copy", "-b", bundleInfo.RefDigest, "--to-tar", tempBundleTarFile})
+		imgpkg.Run([]string{"copy", "--tar", tempBundleTarFile, "--to-repo", fakeRegistry.ReferenceOnTestServer("copied-bundle")})
+	})
+
+	t.Run("When a tar contains an ImageIndex that contains an image with a non-distributable layer", func(t *testing.T) {
+		env := helpers.BuildEnv(t)
+		imgpkg := helpers.Imgpkg{t, helpers.Logger{}, env.ImgpkgPath}
+		defer env.Cleanup()
+		outputBuffer := bytes.NewBufferString("")
+
+		fakeRegistry := helpers.NewFakeRegistry(t)
+		defer fakeRegistry.CleanUp()
+
+		imageWithNonDistributableLayer := fakeRegistry.WithRandomImage("repo/image_belonging_to_image_index").WithNonDistributableLayer()
+		nestedImageIndex := fakeRegistry.WithImageIndex("repo/nestedimageindex", imageWithNonDistributableLayer.Image)
+
+		randomImage := fakeRegistry.WithRandomImage("repo/randomimage")
+		imageIndex := fakeRegistry.WithImageIndex("repo/imageindex", nestedImageIndex.ImageIndex, randomImage.Image)
+
+		bundleInfo := fakeRegistry.WithBundleFromPath("repo/bundle", "assets/bundle").WithImageRefs([]lockconfig.ImageRef{
+			{Image: imageIndex.RefDigest},
+		})
+
+		fakeRegistry.Build()
+
+		tempBundleTarDir := env.Assets.CreateTempFolder("bundle-tar")
+		tempBundleTarFile := filepath.Join(tempBundleTarDir, "bundle-tar.tgz")
+		imgpkg.Run([]string{"copy", "-b", bundleInfo.RefDigest, "--to-tar", tempBundleTarFile})
+		imgpkg.RunWithOpts([]string{"copy", "--tar", tempBundleTarFile, "--to-repo", fakeRegistry.ReferenceOnTestServer("copied-bundle")}, helpers.RunOpts{
+			AllowError:   false,
+			StderrWriter: outputBuffer,
+			StdoutWriter: outputBuffer,
+		})
+
+		assert.Contains(t, outputBuffer.String(), "Skipped layer due to it being non-distributable. If you would like to include non-distributable layers, use the --include-non-distributable flag")
+	})
+}

--- a/test/helpers/image_factory.go
+++ b/test/helpers/image_factory.go
@@ -107,3 +107,17 @@ func (i *ImageFactory) PushImageWithLayerSize(imgRef string, size int64) string 
 
 	return digest.String()
 }
+
+func (i *ImageFactory) PushImageIndex(imgRef string) {
+	imageRef, err := name.ParseReference(imgRef, name.WeakValidation)
+	if err != nil {
+		i.T.Fatalf(err.Error())
+	}
+
+	index, err := random.Index(1024, 1, 2)
+
+	err = remote.WriteIndex(imageRef, index, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		i.T.Fatalf(err.Error())
+	}
+}


### PR DESCRIPTION
Opening as a draft as there is still work to do. Namely

- [x] backfill test copying a tarfile with an ImageIndex