### PR TITLE
Bug Fix: copying from a tarfile to a registry fails if the image doesn't exist

### DIFF
--- a/pkg/imgpkg/imageset/image_set.go
+++ b/pkg/imgpkg/imageset/image_set.go
@@ -189,11 +189,13 @@ func (ImageSet) mountableImage(imageWithRef imagedesc.ImageWithRef, uploadTagRef
 	if imageBlobsCanBeMounted(itemRef, uploadTagRef) {
 		descriptor, err := registry.Get(itemRef)
 		if err != nil {
-			return nil, fmt.Errorf("Getting mountable image failed: %s: %s", itemRef, err)
+			// If a performance improvement cannot be done, fallback to the 'non-performant' way
+			return regv1.Image(imageWithRef), nil
 		}
 		artifactToWrite, err := descriptor.Image()
 		if err != nil {
-			return nil, fmt.Errorf("Getting mountable image from descriptor failed: %s: %s", itemRef, err)
+			// If a performance improvement cannot be done, fallback to the 'non-performant' way
+			return regv1.Image(imageWithRef), nil
 		}
 		return artifactToWrite, nil
 	}

--- a/test/helpers/fake_registry.go
+++ b/test/helpers/fake_registry.go
@@ -221,6 +221,17 @@ func (r *FakeTestRegistryBuilder) WithImageIndex(imageIndexName string, images .
 	return r.updateState(imageIndexName, nil, index, "")
 }
 
+func (r *FakeTestRegistryBuilder) RemoveImage(imageRef string) {
+	u, err := url.Parse(r.server.URL)
+	assert.NoError(r.t, err)
+
+	imageRefWithTestRegistry, err := name.ParseReference(fmt.Sprintf("%s/%s", u.Host, imageRef))
+	assert.NoError(r.t, err)
+
+	err = regremote.Delete(imageRefWithTestRegistry)
+	assert.NoError(r.t, err)
+}
+
 type BundleInfo struct {
 	r          *FakeTestRegistryBuilder
 	Image      v1.Image


### PR DESCRIPTION
This is a draft PR. Left TODO:

- [x] backfill test


# Information for folk who are click the merge button:

- This PR is based off (cherry-picked) https://github.com/vmware-tanzu/carvel-imgpkg/pull/126

It depends on changes made to test helper files (specifically the fake registry.go)

- Please merge #126 first. some tidying up on this PR will need to be done. and then click merge :-) 

