### PR TITLE
Maintain owner permission bits on files

### DIFF
--- a/pkg/imgpkg/image/tar_image.go
+++ b/pkg/imgpkg/image/tar_image.go
@@ -126,8 +126,8 @@ func (i *TarImage) addFileToTar(fullPath, relPath string, info os.FileInfo, tarW
 	header := &tar.Header{
 		Name:     relPath,
 		Size:     info.Size(),
-		Mode:     0600,        // static
-		ModTime:  time.Time{}, // static
+		Mode:     int64(info.Mode() & 0700), // static
+		ModTime:  time.Time{},               // static
 		Typeflag: tar.TypeReg,
 	}
 

--- a/test/e2e/assets/bundle_file_permissions/.imgpkg/bundle.yml
+++ b/test/e2e/assets/bundle_file_permissions/.imgpkg/bundle.yml
@@ -1,0 +1,9 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: basic
+authors:
+- name: Carvel Team
+  email: carvel@vmware.com
+websites:
+- url: carvel.dev/imgpkg

--- a/test/e2e/assets/bundle_file_permissions/.imgpkg/images.yml
+++ b/test/e2e/assets/bundle_file_permissions/.imgpkg/images.yml
@@ -1,0 +1,3 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: ImagesLock
+images:

--- a/test/e2e/assets/bundle_file_permissions/exec_file.sh
+++ b/test/e2e/assets/bundle_file_permissions/exec_file.sh
@@ -1,0 +1,1 @@
+echo "Hello world"

--- a/test/e2e/assets/bundle_file_permissions/read_only_config.yml
+++ b/test/e2e/assets/bundle_file_permissions/read_only_config.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: simple-app
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    simple-app: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: simple-app
+spec:
+  selector:
+    matchLabels:
+      simple-app: ""
+  template:
+    metadata:
+      labels:
+        simple-app: ""
+    spec:
+      containers:
+      - name: simple-app
+        image: docker.io/dkalinin/k8s-simple-app
+        env:
+          - name: HELLO_MSG
+            value: stranger

--- a/test/e2e/assets/bundle_file_permissions/read_write_config.yml
+++ b/test/e2e/assets/bundle_file_permissions/read_write_config.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: simple-app
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    simple-app: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: simple-app
+spec:
+  selector:
+    matchLabels:
+      simple-app: ""
+  template:
+    metadata:
+      labels:
+        simple-app: ""
+    spec:
+      containers:
+      - name: simple-app
+        image: docker.io/dkalinin/k8s-simple-app
+        env:
+          - name: HELLO_MSG
+            value: stranger

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -5,10 +5,14 @@ package e2e
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/k14s/imgpkg/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPushBundleOfBundles(t *testing.T) {
@@ -34,5 +38,37 @@ images:
 		env.BundleFactory.AddFileToBundle(filepath.Join(".imgpkg", "images.yml"), imagesLockYAML)
 
 		imgpkg.Run([]string{"push", "-b", env.Image, "-f", bundleDir})
+	})
+}
+
+func TestPushFilesPermissions(t *testing.T) {
+	env := helpers.BuildEnv(t)
+	logger := helpers.Logger{}
+	imgpkg := helpers.Imgpkg{T: t, L: helpers.Logger{}, ImgpkgPath: env.ImgpkgPath}
+	defer env.Cleanup()
+
+	// We need this chmod, because in the github action this file permission is converted into
+	// u+rw even if in the this repository the permission is correct
+	require.NoError(t, os.Chmod(filepath.Join(".", "assets", "bundle_file_permissions", "read_only_config.yml"), 0400))
+
+	logger.Section("Push bundle with different permissions files", func() {
+		imgpkg.Run([]string{"push", "-f", "./assets/bundle_file_permissions", "-b", env.Image})
+	})
+	bundleDir := env.Assets.CreateTempFolder("bundle-location")
+
+	logger.Section("Pull bundle", func() {
+		imgpkg.Run([]string{"pull", "-b", env.Image, "-o", bundleDir})
+	})
+
+	logger.Section("Check files permissions did not change", func() {
+		info, err := os.Stat(filepath.Join(bundleDir, "exec_file.sh"))
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0700), info.Mode(), "have -rwx------ permissions")
+		info, err = os.Stat(filepath.Join(bundleDir, "read_only_config.yml"))
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0400), info.Mode(), "have -r-------- permissions")
+		info, err = os.Stat(filepath.Join(bundleDir, "read_write_config.yml"))
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0600), info.Mode(), "have -rw------- permissions")
 	})
 }


### PR DESCRIPTION
When pushing an Image to the Registry, imgpkg was forcing all the files to have permission 0600. With this change imgpkg now keeps the owner permission of every file (Group and All Permission are still set to 0 for security reasons)

This is a breaking change because an Image created with an older version of `imgpkg` will produce a different SHA, because now we are preserving the owner permissions.

Related to #93 