### PR TITLE
Add bundle dir validations

### DIFF
--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -114,7 +114,7 @@ func (b Contents) validateImgpkgDirs(imgpkgDirs []string) error {
 
 		msg := fmt.Sprintf("This directory is not a bundle. It it is missing %s", imgpkgPath)
 		if len(imgpkgDirs) > 0 {
-			msg = fmt.Sprintf("This directory is not a bundle. It it is missing a single instance of %s and instead has %s", imgpkgPath, strings.Join(imgpkgDirs, ", "))
+			msg = fmt.Sprintf("This directory constains multiple bundle definitions. Only a single instance of %s can be provided and instead these were provided %s", imgpkgPath, strings.Join(imgpkgDirs, ", "))
 		}
 
 		return bundleValidationError{msg}
@@ -131,7 +131,7 @@ func (b Contents) validateImgpkgDirs(imgpkgDirs []string) error {
 		if filepath.Dir(path) == flagPath {
 			imgpkgPath := filepath.Join(path, ImagesLockFile)
 			if _, err := os.Stat(imgpkgPath); os.IsNotExist(err) {
-				msg := fmt.Sprintf("The bundle expected '%s' to exist, but it wasn't found", imgpkgPath)
+				msg := fmt.Sprintf("The bundle expected .imgpkg/images.yml to exist, but it wasn't found in the path %s", imgpkgPath)
 
 				return bundleValidationError{msg}
 			}

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -110,14 +110,18 @@ func (b *Contents) findImgpkgDirs() ([]string, error) {
 
 func (b Contents) validateImgpkgDirs(imgpkgDirs []string) error {
 	if len(imgpkgDirs) != 1 {
-		return bundleValidationError{
-			fmt.Sprintf("Expected one '%s' dir, got %d: %s",
-				ImgpkgDir, len(imgpkgDirs), strings.Join(imgpkgDirs, ", "))}
+		imgpkgPath := filepath.Join(ImgpkgDir, ImagesLockFile)
+
+		msg := fmt.Sprintf("This directory is not a bundle. It it is missing %s", imgpkgPath)
+		if len(imgpkgDirs) > 0 {
+			msg = fmt.Sprintf("This directory is not a bundle. It it is missing a single instance of %s and instead has %s", imgpkgPath, strings.Join(imgpkgDirs, ", "))
+		}
+
+		return bundleValidationError{msg}
 	}
 
-	path := imgpkgDirs[0]
-
 	// make sure it is a child of one input dir
+	path := imgpkgDirs[0]
 	for _, flagPath := range b.paths {
 		flagPath, err := filepath.Abs(flagPath)
 		if err != nil {
@@ -125,13 +129,21 @@ func (b Contents) validateImgpkgDirs(imgpkgDirs []string) error {
 		}
 
 		if filepath.Dir(path) == flagPath {
+			imgpkgPath := filepath.Join(path, ImagesLockFile)
+			if _, err := os.Stat(imgpkgPath); os.IsNotExist(err) {
+				msg := fmt.Sprintf("The bundle expected '%s' to exist, but it wasn't found", imgpkgPath)
+
+				return bundleValidationError{msg}
+			}
+
 			return nil
 		}
 	}
 
-	return bundleValidationError{
-		fmt.Sprintf("Expected '%s' directory, to be a direct child of one of: %s; was %s",
-			ImgpkgDir, strings.Join(b.paths, ", "), path)}
+	msg := fmt.Sprintf("Expected '%s' directory, to be a direct child of one of: %s; was %s",
+		ImgpkgDir, strings.Join(b.paths, ", "), path)
+
+	return bundleValidationError{msg}
 }
 
 type bundleValidationError struct {


### PR DESCRIPTION
Fixes #115.

Testing: successfully ran `./hack/test-all-local-registry.sh 5000`.

Notes:
👋   - first time contributor!

I made the assumption that for a bundle to be considered a bundle, it needs to have the `.imgpkg` directory. And for it to be a valid bundle, it needs to also include the `images.yml` file in its directory. I wasn't sure if to qualify as a bundle actually the entire `.imgpkg/images.yml` must exist. If this is so, I would change the validations a bit.

There might be an opportunity to converge more of the related existing tests in the  `push_test.go` file into the table test added inside the `TestBundleDirectoryErrors` test. If this PR is going in the right direction, in regards to converging the other tests, I can:
- do nothing
- include that refactoring in this PR
- open a separate PR just for that.

Let me know!