### PR TITLE
Change the default tag from imgpkg

### DIFF
--- a/pkg/imgpkg/imageset/image_set.go
+++ b/pkg/imgpkg/imageset/image_set.go
@@ -199,7 +199,7 @@ func buildUploadTagRef(item imagedesc.ImageOrIndex, importRepo regname.Repositor
 		return regname.Tag{}, err
 	}
 
-	tag := fmt.Sprintf("imgpkg-%s-%s", itemDigest.Algorithm, itemDigest.Hex)
+	tag := fmt.Sprintf("%s-%s.imgpkg", itemDigest.Algorithm, itemDigest.Hex)
 	uploadTagRef, err := regname.NewTag(fmt.Sprintf("%s:%s", importRepo.Name(), tag))
 	if err != nil {
 		return regname.Tag{}, fmt.Errorf("Building upload tag image ref: %s", err)

--- a/test/e2e/copy_from_image_test.go
+++ b/test/e2e/copy_from_image_test.go
@@ -52,6 +52,12 @@ func TestCopyImageToRepoDestinationAndOutputImageLockFileAndPreserveImageTag(t *
 
 		require.NoError(t, env.Assert.ValidateImagesPresenceInRegistry([]string{fmt.Sprintf("%s:%v", env.RelocationRepo, tag)}))
 	})
+
+	logger.Section("Check default tag was created", func() {
+		algorithmAndSHA := strings.Split(imageDigest, "@")[1]
+		splitAlgAndSHA := strings.Split(algorithmAndSHA, ":")
+		require.NoError(t, env.Assert.ValidateImagesPresenceInRegistry([]string{fmt.Sprintf("%s:%s-%s.imgpkg", env.RelocationRepo, splitAlgAndSHA[0], splitAlgAndSHA[1])}))
+	})
 }
 
 func TestCopyAnImageFromATarToARepoThatDoesNotContainNonDistributableLayersButTheFlagWasIncluded(t *testing.T) {


### PR DESCRIPTION
imgpkg when copies an image always adds a default tag to it. The format of the tag is `{SHA Algorigthm}-{SHA}.imgpkg`

Related to #144 