### PR TITLE
Collect images from bundle repo

### DIFF
--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -34,21 +34,12 @@ func (o *Bundle) buildAllImagesLock(throttleReq *util.Throttle, processedImgs *p
 	}
 
 	resultImagesLock := NewImagesLock(lockconfig.ImagesLock{}, o.imgRetriever, o.Repo())
+	currentImagesLock := NewImagesLock(imagesLock, o.imgRetriever, o.Repo())
 
 	errChan := make(chan error, len(imagesLock.Images))
 	mutex := &sync.Mutex{}
 
-	bImagesLock := NewImagesLock(imagesLock, o.imgRetriever, o.Repo())
-	// We generate the locations at this point.
-	// This is done to ensure that the first place we look for each image is in
-	// the bundle repository we are currently processing, only after will try to
-	// check the original location
-	err = bImagesLock.GenerateImagesLocations()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, image := range bImagesLock.ImageRefs() {
+	for _, image := range currentImagesLock.ImageRefs() {
 		if skip := processedImgs.CheckAndAddImage(image.Image); skip {
 			errChan <- nil
 			continue

--- a/pkg/imgpkg/bundle/bundle_test.go
+++ b/pkg/imgpkg/bundle/bundle_test.go
@@ -24,7 +24,7 @@ func TestPullBundleWritingContentsToDisk(t *testing.T) {
 	pullNestedBundles := false
 
 	t.Run("bundle referencing an image", func(t *testing.T) {
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		fakeRegistry.WithBundleFromPath("repo/some-bundle-name", "test_assets/bundle").WithEveryImageFromPath("test_assets/image_with_config", map[string]string{})
@@ -48,7 +48,7 @@ func TestPullBundleWritingContentsToDisk(t *testing.T) {
 
 	t.Run("bundle referencing another bundle that references another bundle does *not* pull nested bundles", func(t *testing.T) {
 		// setup
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_icecream_with_single_bundle - dependsOn - icecream/bundle - dependsOn - apples/bundle
@@ -81,7 +81,7 @@ func TestPullNestedBundlesWritingContentsToDisk(t *testing.T) {
 	pullNestedBundles := true
 
 	t.Run("bundle referencing an image", func(t *testing.T) {
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 		fakeRegistry.WithBundleFromPath("repo/some-bundle-name", "test_assets/bundle").WithEveryImageFromPath("test_assets/image_with_config", map[string]string{})
 
@@ -104,7 +104,7 @@ func TestPullNestedBundlesWritingContentsToDisk(t *testing.T) {
 	})
 
 	t.Run("bundle referencing another bundle does pull nested bundles", func(t *testing.T) {
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_icecream_with_single_bundle - dependsOn - icecream/bundle
@@ -131,7 +131,7 @@ func TestPullNestedBundlesWritingContentsToDisk(t *testing.T) {
 
 	t.Run("bundle referencing another bundle that references another bundle does pull nested bundles", func(t *testing.T) {
 		// setup
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_icecream_with_single_bundle - dependsOn - icecream/bundle - dependsOn - apples/bundle
@@ -174,7 +174,7 @@ func TestPullNestedBundlesLocalizesImagesLockFile(t *testing.T) {
 	pullNestedBundles := true
 
 	t.Run("bundle referencing another bundle in the same repo updates both bundle's imageslock", func(t *testing.T) {
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		randomImageColocatedWithIcecreamBundle := fakeRegistry.WithRandomImage("icecream/bundle")
@@ -226,10 +226,10 @@ kind: ImagesLock
 	})
 
 	t.Run("bundle referencing two bundles, only 1 is relocated, should update only the 1 that is relocated imageslock", func(t *testing.T) {
-		fakePublicRegistry := helpers.NewFakeRegistry(t)
+		fakePublicRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakePublicRegistry.CleanUp()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		randomImageFromFakeRegistry := fakeRegistry.WithRandomImage("icecream/bundle")
@@ -290,7 +290,7 @@ func TestPullBundleOutputToUser(t *testing.T) {
 		output := bytes.NewBufferString("")
 		writerUI := ui.NewWriterUI(output, output, nil)
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		fakeRegistry.WithBundleFromPath("repo/some-bundle-name", "test_assets/bundle").WithEveryImageFromPath("test_assets/image_with_config", map[string]string{})
@@ -315,7 +315,7 @@ One or more images not found in bundle repo; skipping lock file update`, bundleN
 	t.Run("bundle referencing another bundle", func(t *testing.T) {
 		output := bytes.NewBufferString("")
 		writerUI := ui.NewWriterUI(output, output, nil)
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_icecream_with_single_bundle - dependsOn - icecream/bundle
@@ -348,7 +348,7 @@ func TestPullAllNestedBundlesOutputToUser(t *testing.T) {
 	t.Run("bundle referencing another collocated bundle", func(t *testing.T) {
 		defer output.Reset()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		randomImageColocatedWithIcecreamBundle := fakeRegistry.WithRandomImage("icecream/bundle")
@@ -389,7 +389,7 @@ The bundle repo \(%s\) is hosting every image specified in the bundle's Images L
 	t.Run("bundle referencing another *not* colocated bundle", func(t *testing.T) {
 		defer output.Reset()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_icecream_with_single_bundle - dependsOn - icecream/bundle
@@ -421,7 +421,7 @@ One or more images not found in bundle repo; skipping lock file update`, bundleN
 	t.Run("bundle referencing multiple of the same bundles", func(t *testing.T) {
 		defer output.Reset()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_with_multiple_bundle - dependsOn - [library/image_with_a_smile, library/image_with_non_distributable_layer, library/image_with_config] - dependsOn - apples/bundle
@@ -476,7 +476,7 @@ One or more images not found in bundle repo; skipping lock file update`, bundleW
 	t.Run("bundle referencing another bundle that references another bundle", func(t *testing.T) {
 		defer output.Reset()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		// repo/bundle_icecream_with_single_bundle - dependsOn - icecream/bundle - dependsOn - apples/bundle

--- a/pkg/imgpkg/bundle/bundlefakes/fake_images_metadata_writer.go
+++ b/pkg/imgpkg/bundle/bundlefakes/fake_images_metadata_writer.go
@@ -24,6 +24,19 @@ type FakeImagesMetadataWriter struct {
 		result1 v1.Hash
 		result2 error
 	}
+	FirstImageExistsStub        func([]string) (string, error)
+	firstImageExistsMutex       sync.RWMutex
+	firstImageExistsArgsForCall []struct {
+		arg1 []string
+	}
+	firstImageExistsReturns struct {
+		result1 string
+		result2 error
+	}
+	firstImageExistsReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	GenericStub        func(name.Reference) (v1.Descriptor, error)
 	genericMutex       sync.RWMutex
 	genericArgsForCall []struct {
@@ -152,6 +165,75 @@ func (fake *FakeImagesMetadataWriter) DigestReturnsOnCall(i int, result1 v1.Hash
 	}
 	fake.digestReturnsOnCall[i] = struct {
 		result1 v1.Hash
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImagesMetadataWriter) FirstImageExists(arg1 []string) (string, error) {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.firstImageExistsMutex.Lock()
+	ret, specificReturn := fake.firstImageExistsReturnsOnCall[len(fake.firstImageExistsArgsForCall)]
+	fake.firstImageExistsArgsForCall = append(fake.firstImageExistsArgsForCall, struct {
+		arg1 []string
+	}{arg1Copy})
+	stub := fake.FirstImageExistsStub
+	fakeReturns := fake.firstImageExistsReturns
+	fake.recordInvocation("FirstImageExists", []interface{}{arg1Copy})
+	fake.firstImageExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImagesMetadataWriter) FirstImageExistsCallCount() int {
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
+	return len(fake.firstImageExistsArgsForCall)
+}
+
+func (fake *FakeImagesMetadataWriter) FirstImageExistsCalls(stub func([]string) (string, error)) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = stub
+}
+
+func (fake *FakeImagesMetadataWriter) FirstImageExistsArgsForCall(i int) []string {
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
+	argsForCall := fake.firstImageExistsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImagesMetadataWriter) FirstImageExistsReturns(result1 string, result2 error) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = nil
+	fake.firstImageExistsReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImagesMetadataWriter) FirstImageExistsReturnsOnCall(i int, result1 string, result2 error) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = nil
+	if fake.firstImageExistsReturnsOnCall == nil {
+		fake.firstImageExistsReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.firstImageExistsReturnsOnCall[i] = struct {
+		result1 string
 		result2 error
 	}{result1, result2}
 }
@@ -479,6 +561,8 @@ func (fake *FakeImagesMetadataWriter) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.digestMutex.RLock()
 	defer fake.digestMutex.RUnlock()
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
 	fake.genericMutex.RLock()
 	defer fake.genericMutex.RUnlock()
 	fake.getMutex.RLock()

--- a/pkg/imgpkg/bundle/images_lock.go
+++ b/pkg/imgpkg/bundle/images_lock.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	regname "github.com/google/go-containerregistry/pkg/name"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/image"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 )
@@ -65,7 +64,7 @@ func (o *ImagesLock) LocalizeImagesLock() (lockconfig.ImagesLock, bool, error) {
 			return o.imagesLock, false, err
 		}
 
-		foundImg, err := o.checkImagesExist([]string{imageInBundleRepo, imgRef.Image})
+		foundImg, err := o.imgRetriever.FirstImageExists([]string{imageInBundleRepo, imgRef.Image})
 		if err != nil {
 			return o.imagesLock, false, err
 		}
@@ -85,21 +84,6 @@ func (o *ImagesLock) LocalizeImagesLock() (lockconfig.ImagesLock, bool, error) {
 
 	imagesLock.Images = imageRefs
 	return imagesLock, false, nil
-}
-
-func (o *ImagesLock) checkImagesExist(urls []string) (string, error) {
-	var err error
-	for _, img := range urls {
-		ref, parseErr := regname.NewDigest(img)
-		if parseErr != nil {
-			return "", parseErr
-		}
-		_, err = o.imgRetriever.Digest(ref)
-		if err == nil {
-			return img, nil
-		}
-	}
-	return "", fmt.Errorf("Checking image existence: %s", err)
 }
 
 func (o *ImagesLock) imageRelativeToBundle(img string) (string, error) {

--- a/pkg/imgpkg/bundle/images_lock_test.go
+++ b/pkg/imgpkg/bundle/images_lock_test.go
@@ -33,6 +33,9 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 			},
 		}
 		fakeImagesMetadata := &imagefakes.FakeImagesMetadata{}
+		fakeImagesMetadata.FirstImageExistsCalls(func(strings []string) (string, error) {
+			return strings[0], nil
+		})
 		subject := ctlbundle.NewImagesLock(imagesLock, fakeImagesMetadata, "some.repo.io/bundle")
 
 		newImagesLock, skipped, err := subject.LocalizeImagesLock()

--- a/pkg/imgpkg/bundle/images_lock_test.go
+++ b/pkg/imgpkg/bundle/images_lock_test.go
@@ -43,8 +43,8 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 		assert.False(t, skipped)
 
 		require.Len(t, newImagesLock.Images, 2)
-		assert.Equal(t, "some.repo.io/bundle@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", newImagesLock.Images[0].Locations()[0])
-		assert.Equal(t, "some.repo.io/bundle@sha256:45f3926bca9fc42adb650fef2a41250d77841dde49afc8adc7c0c633b3d5f27a", newImagesLock.Images[1].Locations()[0])
+		assert.Equal(t, "some.repo.io/bundle@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", newImagesLock.Images[0].PrimaryLocation())
+		assert.Equal(t, "some.repo.io/bundle@sha256:45f3926bca9fc42adb650fef2a41250d77841dde49afc8adc7c0c633b3d5f27a", newImagesLock.Images[1].PrimaryLocation())
 	})
 
 	t.Run("When one image cannot be found in the bundle repository, it returns the old image location and skipped == true", func(t *testing.T) {
@@ -69,8 +69,8 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 		assert.True(t, skipped)
 
 		require.Len(t, newImagesLock.Images, 2)
-		assert.Equal(t, "some.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", newImagesLock.Images[0].Locations()[0])
-		assert.Equal(t, "some.repo.io/img2@sha256:45f3926bca9fc42adb650fef2a41250d77841dde49afc8adc7c0c633b3d5f27a", newImagesLock.Images[1].Locations()[0])
+		assert.Equal(t, "some.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", newImagesLock.Images[0].PrimaryLocation())
+		assert.Equal(t, "some.repo.io/img2@sha256:45f3926bca9fc42adb650fef2a41250d77841dde49afc8adc7c0c633b3d5f27a", newImagesLock.Images[1].PrimaryLocation())
 	})
 }
 
@@ -101,9 +101,11 @@ func TestImagesLock_Merge(t *testing.T) {
 		imagesRefs := subject.ImageRefs()
 		require.Len(t, imagesRefs, 3)
 		require.Equal(t, "original.repo.io/img4@sha256:4322479b268761c699a2b8c09ac6877acdc17d8f2c1ce2a7f5ebc0a8ee754332", imagesRefs[2].Image)
-		require.Len(t, imagesRefs[2].Locations(), 1)
-		locations := imagesRefs[2].Locations()
-		assert.Equal(t, "original.repo.io/img4@sha256:4322479b268761c699a2b8c09ac6877acdc17d8f2c1ce2a7f5ebc0a8ee754332", locations[0])
+		expectedLocations := []string{
+			"some.repo.io/bundle@sha256:4322479b268761c699a2b8c09ac6877acdc17d8f2c1ce2a7f5ebc0a8ee754332",
+			"original.repo.io/img4@sha256:4322479b268761c699a2b8c09ac6877acdc17d8f2c1ce2a7f5ebc0a8ee754332",
+		}
+		require.Equal(t, expectedLocations, imagesRefs[2].Locations())
 	})
 
 	t.Run("when images are repeated ignores new image", func(t *testing.T) {

--- a/pkg/imgpkg/bundle/images_lock_test.go
+++ b/pkg/imgpkg/bundle/images_lock_test.go
@@ -71,49 +71,6 @@ func TestImagesLock_LocalizeImagesLock(t *testing.T) {
 	})
 }
 
-func TestImagesLock_LocationPrunedImagesLock(t *testing.T) {
-	t.Run("when image cannot be found in primary location, it prunes that location from the list", func(t *testing.T) {
-		imgRef := lockconfig.ImageRef{
-			Image: "some.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80",
-		}
-		imgRef.AddLocation("second.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80")
-		imgRef.AddLocation("first.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80")
-		imagesLock := lockconfig.ImagesLock{
-			Images: []lockconfig.ImageRef{
-				imgRef,
-			},
-		}
-		fakeImagesMetadata := &imagefakes.FakeImagesMetadata{}
-
-		// does not find image in first.repo.io/img1
-		fakeImagesMetadata.DigestReturnsOnCall(0, regv1.Hash{}, errors.New("not found"))
-
-		subject := ctlbundle.NewImagesLock(imagesLock, fakeImagesMetadata, "some.repo.io/bundle")
-		imgRefs, err := subject.LocationPrunedImageRefs(5)
-		require.NoError(t, err)
-		assert.Equal(t, "second.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", imgRefs[0].PrimaryLocation())
-	})
-
-	t.Run("when image is found in primary location, it does not prune any location", func(t *testing.T) {
-		imgRef := lockconfig.ImageRef{
-			Image: "some.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80",
-		}
-		imgRef.AddLocation("second.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80")
-		imgRef.AddLocation("first.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80")
-		imagesLock := lockconfig.ImagesLock{
-			Images: []lockconfig.ImageRef{
-				imgRef,
-			},
-		}
-		fakeImagesMetadata := &imagefakes.FakeImagesMetadata{}
-
-		subject := ctlbundle.NewImagesLock(imagesLock, fakeImagesMetadata, "some.repo.io/bundle")
-		imgRefs, err := subject.LocationPrunedImageRefs(1)
-		require.NoError(t, err)
-		assert.Equal(t, "first.repo.io/img1@sha256:27fde5fa39e3c97cb1e5dabfb664784b605a592d5d2df5482d744742efebba80", imgRefs[0].PrimaryLocation())
-	})
-}
-
 func TestImagesLock_Merge(t *testing.T) {
 	t.Run("appends the images from the provided ImagesLock", func(t *testing.T) {
 		parentImagesLock := lockconfig.ImagesLock{

--- a/pkg/imgpkg/cmd/copy_repo_src.go
+++ b/pkg/imgpkg/cmd/copy_repo_src.go
@@ -153,11 +153,7 @@ func (c CopyRepoSrc) getBundleImageRefs(bundleRef string) (*ctlbundle.Bundle, []
 		return nil, nil, err
 	}
 
-	imageRefs, err := imgLock.LocationPrunedImageRefs(c.Concurrency)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Pruning image ref locations: %s", err)
-	}
-	return bundle, imageRefs, nil
+	return bundle, imgLock.ImageRefs(), nil
 }
 
 func imageRefDescriptorsMediaTypes(ids *imagedesc.ImageRefDescriptors) []string {

--- a/pkg/imgpkg/cmd/copy_repo_src_test.go
+++ b/pkg/imgpkg/cmd/copy_repo_src_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 
 func TestToTarBundle(t *testing.T) {
 	bundleName := "library/bundle"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	bundleWithImages := fakeRegistry.WithBundleFromPath(bundleName, "test_assets/bundle").
 		WithEveryImageFromPath("test_assets/image_with_config", map[string]string{})
 
@@ -105,7 +105,7 @@ bundle:
 
 func TestToTarBundleContainingNonDistributableLayers(t *testing.T) {
 	bundleName := "library/bundle"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	defer fakeRegistry.CleanUp()
 	randomImage := fakeRegistry.WithRandomImage("library/image_with_config")
 	randomImageWithNonDistributableLayer := fakeRegistry.
@@ -203,7 +203,7 @@ images:
 
 func TestToTarImage(t *testing.T) {
 	imageName := "library/image"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	fakeRegistry.WithImageFromPath(imageName, "test_assets/image_with_config", map[string]string{})
 	defer fakeRegistry.CleanUp()
 
@@ -253,7 +253,7 @@ func TestToTarImage(t *testing.T) {
 
 func TestToTarImageContainingNonDistributableLayers(t *testing.T) {
 	imageName := "library/image"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	fakeRegistry.WithImageFromPath(imageName, "test_assets/image_with_config", map[string]string{}).
 		WithNonDistributableLayer()
 	defer fakeRegistry.CleanUp()
@@ -292,7 +292,7 @@ func TestToTarImageContainingNonDistributableLayers(t *testing.T) {
 
 func TestToTarImageIndex(t *testing.T) {
 	imageName := "library/image"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	fakeRegistry.WithARandomImageIndex(imageName)
 	defer fakeRegistry.CleanUp()
 
@@ -348,7 +348,7 @@ func TestToTarImageIndex(t *testing.T) {
 
 func TestToRepoBundleContainingANestedBundle(t *testing.T) {
 	bundleName := "library/bundle"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	defer fakeRegistry.CleanUp()
 	randomImage := fakeRegistry.WithRandomImage("library/image_with_config")
 	randomImage2 := fakeRegistry.WithRandomImage("library/image_with_config_2")
@@ -453,9 +453,9 @@ images:
 }
 
 func TestToRepoBundleWithMultipleRegistries(t *testing.T) {
-	fakeDockerhubRegistry := helpers.NewFakeRegistry(t)
+	fakeDockerhubRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	defer fakeDockerhubRegistry.CleanUp()
-	fakePrivateRegistry := helpers.NewFakeRegistry(t)
+	fakePrivateRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	defer fakePrivateRegistry.CleanUp()
 
 	sourceBundleName := "library/bundle"
@@ -518,7 +518,7 @@ bundle:
 
 func TestToRepoImage(t *testing.T) {
 	imageName := "library/image"
-	fakeRegistry := helpers.NewFakeRegistry(t)
+	fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 	image1 := fakeRegistry.WithImageFromPath(imageName, "test_assets/image_with_config", map[string]string{})
 	defer fakeRegistry.CleanUp()
 	subject := subject

--- a/pkg/imgpkg/image/imagefakes/fake_images_metadata.go
+++ b/pkg/imgpkg/image/imagefakes/fake_images_metadata.go
@@ -24,6 +24,19 @@ type FakeImagesMetadata struct {
 		result1 v1.Hash
 		result2 error
 	}
+	FirstImageExistsStub        func([]string) (string, error)
+	firstImageExistsMutex       sync.RWMutex
+	firstImageExistsArgsForCall []struct {
+		arg1 []string
+	}
+	firstImageExistsReturns struct {
+		result1 string
+		result2 error
+	}
+	firstImageExistsReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	GenericStub        func(name.Reference) (v1.Descriptor, error)
 	genericMutex       sync.RWMutex
 	genericArgsForCall []struct {
@@ -140,6 +153,75 @@ func (fake *FakeImagesMetadata) DigestReturnsOnCall(i int, result1 v1.Hash, resu
 	}
 	fake.digestReturnsOnCall[i] = struct {
 		result1 v1.Hash
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImagesMetadata) FirstImageExists(arg1 []string) (string, error) {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.firstImageExistsMutex.Lock()
+	ret, specificReturn := fake.firstImageExistsReturnsOnCall[len(fake.firstImageExistsArgsForCall)]
+	fake.firstImageExistsArgsForCall = append(fake.firstImageExistsArgsForCall, struct {
+		arg1 []string
+	}{arg1Copy})
+	stub := fake.FirstImageExistsStub
+	fakeReturns := fake.firstImageExistsReturns
+	fake.recordInvocation("FirstImageExists", []interface{}{arg1Copy})
+	fake.firstImageExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImagesMetadata) FirstImageExistsCallCount() int {
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
+	return len(fake.firstImageExistsArgsForCall)
+}
+
+func (fake *FakeImagesMetadata) FirstImageExistsCalls(stub func([]string) (string, error)) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = stub
+}
+
+func (fake *FakeImagesMetadata) FirstImageExistsArgsForCall(i int) []string {
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
+	argsForCall := fake.firstImageExistsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImagesMetadata) FirstImageExistsReturns(result1 string, result2 error) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = nil
+	fake.firstImageExistsReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImagesMetadata) FirstImageExistsReturnsOnCall(i int, result1 string, result2 error) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = nil
+	if fake.firstImageExistsReturnsOnCall == nil {
+		fake.firstImageExistsReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.firstImageExistsReturnsOnCall[i] = struct {
+		result1 string
 		result2 error
 	}{result1, result2}
 }
@@ -405,6 +487,8 @@ func (fake *FakeImagesMetadata) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.digestMutex.RLock()
 	defer fake.digestMutex.RUnlock()
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
 	fake.genericMutex.RLock()
 	defer fake.genericMutex.RUnlock()
 	fake.getMutex.RLock()

--- a/pkg/imgpkg/image/images.go
+++ b/pkg/imgpkg/image/images.go
@@ -20,6 +20,7 @@ type ImagesMetadata interface {
 	Digest(regname.Reference) (regv1.Hash, error)
 	Index(regname.Reference) (regv1.ImageIndex, error)
 	Image(regname.Reference) (regv1.Image, error)
+	FirstImageExists(digests []string) (string, error)
 }
 
 type Images struct {
@@ -130,6 +131,10 @@ func (m errImagesMetadata) Index(ref regname.Reference) (regv1.ImageIndex, error
 func (m errImagesMetadata) Image(ref regname.Reference) (regv1.Image, error) {
 	img, err := m.delegate.Image(ref)
 	return img, m.betterErr(ref, err)
+}
+
+func (m errImagesMetadata) FirstImageExists(digests []string) (string, error) {
+	return m.delegate.FirstImageExists(digests)
 }
 
 func (m errImagesMetadata) betterErr(ref regname.Reference, err error) error {

--- a/pkg/imgpkg/imageset/imagesetfakes/fake_images_reader_writer.go
+++ b/pkg/imgpkg/imageset/imagesetfakes/fake_images_reader_writer.go
@@ -24,6 +24,19 @@ type FakeImagesReaderWriter struct {
 		result1 v1.Hash
 		result2 error
 	}
+	FirstImageExistsStub        func([]string) (string, error)
+	firstImageExistsMutex       sync.RWMutex
+	firstImageExistsArgsForCall []struct {
+		arg1 []string
+	}
+	firstImageExistsReturns struct {
+		result1 string
+		result2 error
+	}
+	firstImageExistsReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	GenericStub        func(name.Reference) (v1.Descriptor, error)
 	genericMutex       sync.RWMutex
 	genericArgsForCall []struct {
@@ -134,15 +147,16 @@ func (fake *FakeImagesReaderWriter) Digest(arg1 name.Reference) (v1.Hash, error)
 	fake.digestArgsForCall = append(fake.digestArgsForCall, struct {
 		arg1 name.Reference
 	}{arg1})
+	stub := fake.DigestStub
+	fakeReturns := fake.digestReturns
 	fake.recordInvocation("Digest", []interface{}{arg1})
 	fake.digestMutex.Unlock()
-	if fake.DigestStub != nil {
-		return fake.DigestStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.digestReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -191,21 +205,91 @@ func (fake *FakeImagesReaderWriter) DigestReturnsOnCall(i int, result1 v1.Hash, 
 	}{result1, result2}
 }
 
+func (fake *FakeImagesReaderWriter) FirstImageExists(arg1 []string) (string, error) {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.firstImageExistsMutex.Lock()
+	ret, specificReturn := fake.firstImageExistsReturnsOnCall[len(fake.firstImageExistsArgsForCall)]
+	fake.firstImageExistsArgsForCall = append(fake.firstImageExistsArgsForCall, struct {
+		arg1 []string
+	}{arg1Copy})
+	stub := fake.FirstImageExistsStub
+	fakeReturns := fake.firstImageExistsReturns
+	fake.recordInvocation("FirstImageExists", []interface{}{arg1Copy})
+	fake.firstImageExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImagesReaderWriter) FirstImageExistsCallCount() int {
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
+	return len(fake.firstImageExistsArgsForCall)
+}
+
+func (fake *FakeImagesReaderWriter) FirstImageExistsCalls(stub func([]string) (string, error)) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = stub
+}
+
+func (fake *FakeImagesReaderWriter) FirstImageExistsArgsForCall(i int) []string {
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
+	argsForCall := fake.firstImageExistsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImagesReaderWriter) FirstImageExistsReturns(result1 string, result2 error) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = nil
+	fake.firstImageExistsReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImagesReaderWriter) FirstImageExistsReturnsOnCall(i int, result1 string, result2 error) {
+	fake.firstImageExistsMutex.Lock()
+	defer fake.firstImageExistsMutex.Unlock()
+	fake.FirstImageExistsStub = nil
+	if fake.firstImageExistsReturnsOnCall == nil {
+		fake.firstImageExistsReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.firstImageExistsReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImagesReaderWriter) Generic(arg1 name.Reference) (v1.Descriptor, error) {
 	fake.genericMutex.Lock()
 	ret, specificReturn := fake.genericReturnsOnCall[len(fake.genericArgsForCall)]
 	fake.genericArgsForCall = append(fake.genericArgsForCall, struct {
 		arg1 name.Reference
 	}{arg1})
+	stub := fake.GenericStub
+	fakeReturns := fake.genericReturns
 	fake.recordInvocation("Generic", []interface{}{arg1})
 	fake.genericMutex.Unlock()
-	if fake.GenericStub != nil {
-		return fake.GenericStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.genericReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -260,15 +344,16 @@ func (fake *FakeImagesReaderWriter) Get(arg1 name.Reference) (*remote.Descriptor
 	fake.getArgsForCall = append(fake.getArgsForCall, struct {
 		arg1 name.Reference
 	}{arg1})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -323,15 +408,16 @@ func (fake *FakeImagesReaderWriter) Image(arg1 name.Reference) (v1.Image, error)
 	fake.imageArgsForCall = append(fake.imageArgsForCall, struct {
 		arg1 name.Reference
 	}{arg1})
+	stub := fake.ImageStub
+	fakeReturns := fake.imageReturns
 	fake.recordInvocation("Image", []interface{}{arg1})
 	fake.imageMutex.Unlock()
-	if fake.ImageStub != nil {
-		return fake.ImageStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.imageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -386,15 +472,16 @@ func (fake *FakeImagesReaderWriter) Index(arg1 name.Reference) (v1.ImageIndex, e
 	fake.indexArgsForCall = append(fake.indexArgsForCall, struct {
 		arg1 name.Reference
 	}{arg1})
+	stub := fake.IndexStub
+	fakeReturns := fake.indexReturns
 	fake.recordInvocation("Index", []interface{}{arg1})
 	fake.indexMutex.Unlock()
-	if fake.IndexStub != nil {
-		return fake.IndexStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.indexReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -450,15 +537,16 @@ func (fake *FakeImagesReaderWriter) MultiWrite(arg1 map[name.Reference]remote.Ta
 		arg1 map[name.Reference]remote.Taggable
 		arg2 int
 	}{arg1, arg2})
+	stub := fake.MultiWriteStub
+	fakeReturns := fake.multiWriteReturns
 	fake.recordInvocation("MultiWrite", []interface{}{arg1, arg2})
 	fake.multiWriteMutex.Unlock()
-	if fake.MultiWriteStub != nil {
-		return fake.MultiWriteStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.multiWriteReturns
 	return fakeReturns.result1
 }
 
@@ -511,15 +599,16 @@ func (fake *FakeImagesReaderWriter) WriteImage(arg1 name.Reference, arg2 v1.Imag
 		arg1 name.Reference
 		arg2 v1.Image
 	}{arg1, arg2})
+	stub := fake.WriteImageStub
+	fakeReturns := fake.writeImageReturns
 	fake.recordInvocation("WriteImage", []interface{}{arg1, arg2})
 	fake.writeImageMutex.Unlock()
-	if fake.WriteImageStub != nil {
-		return fake.WriteImageStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.writeImageReturns
 	return fakeReturns.result1
 }
 
@@ -572,15 +661,16 @@ func (fake *FakeImagesReaderWriter) WriteIndex(arg1 name.Reference, arg2 v1.Imag
 		arg1 name.Reference
 		arg2 v1.ImageIndex
 	}{arg1, arg2})
+	stub := fake.WriteIndexStub
+	fakeReturns := fake.writeIndexReturns
 	fake.recordInvocation("WriteIndex", []interface{}{arg1, arg2})
 	fake.writeIndexMutex.Unlock()
-	if fake.WriteIndexStub != nil {
-		return fake.WriteIndexStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.writeIndexReturns
 	return fakeReturns.result1
 }
 
@@ -633,15 +723,16 @@ func (fake *FakeImagesReaderWriter) WriteTag(arg1 name.Tag, arg2 remote.Taggable
 		arg1 name.Tag
 		arg2 remote.Taggable
 	}{arg1, arg2})
+	stub := fake.WriteTagStub
+	fakeReturns := fake.writeTagReturns
 	fake.recordInvocation("WriteTag", []interface{}{arg1, arg2})
 	fake.writeTagMutex.Unlock()
-	if fake.WriteTagStub != nil {
-		return fake.WriteTagStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.writeTagReturns
 	return fakeReturns.result1
 }
 
@@ -692,6 +783,8 @@ func (fake *FakeImagesReaderWriter) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.digestMutex.RLock()
 	defer fake.digestMutex.RUnlock()
+	fake.firstImageExistsMutex.RLock()
+	defer fake.firstImageExistsMutex.RUnlock()
 	fake.genericMutex.RLock()
 	defer fake.genericMutex.RUnlock()
 	fake.getMutex.RLock()

--- a/pkg/imgpkg/lockconfig/images_lock.go
+++ b/pkg/imgpkg/lockconfig/images_lock.go
@@ -153,11 +153,13 @@ func (i *ImageRef) PrimaryLocation() string {
 	return i.Locations()[0]
 }
 
-func (i *ImageRef) DiscardLocationsExcept(viableLocation string) {
-	if viableLocation == i.Image {
-		i.locations = []string{}
-		return
+func (i *ImageRef) DiscardLocationsExcept(viableLocation string) ImageRef {
+	imgRef := i.DeepCopy()
+	if viableLocation == imgRef.Image {
+		imgRef.locations = []string{}
+		return imgRef
 	}
 
-	i.locations = []string{viableLocation}
+	imgRef.locations = []string{viableLocation}
+	return imgRef
 }

--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -177,6 +177,21 @@ func (r Registry) ListTags(repo regname.Repository) ([]string, error) {
 	return regremote.List(overriddenRepo, r.opts...)
 }
 
+func (r Registry) FirstImageExists(digests []string) (string, error) {
+	var err error
+	for _, img := range digests {
+		ref, parseErr := regname.NewDigest(img)
+		if parseErr != nil {
+			return "", parseErr
+		}
+		_, err = r.Digest(ref)
+		if err == nil {
+			return img, nil
+		}
+	}
+	return "", fmt.Errorf("Checking image existence: %s", err)
+}
+
 func newHTTPTransport(opts Opts) (*http.Transport, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -21,7 +21,7 @@ func TestAuth(t *testing.T) {
 		expectedPassword := "expected-password"
 		imageRef := "repo/imgpkg-test"
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		fakeRegistry.WithBasicAuth(expectedUsername, expectedPassword)
 		fakeRegistry.WithRandomImage(imageRef)
 		fakeRegistry.Build()
@@ -43,7 +43,7 @@ func TestAuth(t *testing.T) {
 		expectedToken := "ID_TOKEN"
 		imageRef := "repo/imgpkg-test"
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		fakeRegistry.WithIdentityToken(expectedToken)
 		fakeRegistry.WithRandomImage(imageRef)
 		fakeRegistry.Build()
@@ -65,7 +65,7 @@ func TestAuth(t *testing.T) {
 		expectedToken := "REGISTRY_TOKEN"
 		imageRef := "repo/imgpkg-test"
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		fakeRegistry.WithRegistryToken(expectedToken)
 		fakeRegistry.WithRandomImage(imageRef)
 		fakeRegistry.Build()

--- a/test/e2e/copy_from_tar_test.go
+++ b/test/e2e/copy_from_tar_test.go
@@ -19,7 +19,7 @@ func TestCopyTarSrc(t *testing.T) {
 		imgpkg := helpers.Imgpkg{T: t, L: helpers.Logger{}, ImgpkgPath: env.ImgpkgPath}
 		defer env.Cleanup()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 		imageIndex := fakeRegistry.WithARandomImageIndex("repo/imageindex")
 		bundleInfo := fakeRegistry.WithBundleFromPath("repo/bundle", "assets/bundle").WithImageRefs([]lockconfig.ImageRef{
@@ -40,7 +40,7 @@ func TestCopyTarSrc(t *testing.T) {
 		defer env.Cleanup()
 		outputBuffer := bytes.NewBufferString("")
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 
 		imageWithNonDistributableLayer := fakeRegistry.WithRandomImage("repo/image_belonging_to_image_index").WithNonDistributableLayer()
@@ -72,7 +72,7 @@ func TestCopyTarSrc(t *testing.T) {
 		imgpkg := helpers.Imgpkg{T: t, L: helpers.Logger{}, ImgpkgPath: env.ImgpkgPath}
 		defer env.Cleanup()
 
-		fakeRegistry := helpers.NewFakeRegistry(t)
+		fakeRegistry := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		defer fakeRegistry.CleanUp()
 		randomImage := fakeRegistry.WithRandomImage("repo/randomimage")
 		bundleInfo := fakeRegistry.WithBundleFromPath("repo/bundle", "assets/bundle").WithImageRefs([]lockconfig.ImageRef{

--- a/test/helpers/fake_registry.go
+++ b/test/helpers/fake_registry.go
@@ -374,6 +374,16 @@ func (r *FakeTestRegistryBuilder) RemoveImage(imageRef string) {
 	assert.NoError(r.t, err)
 }
 
+// RemoveByImageRef This function only works as expected before running Build()
+// Prevents the creation in the registry of the image provided
+func (r *FakeTestRegistryBuilder) RemoveByImageRef(imageRef string) {
+	digest, err := name.NewDigest(imageRef)
+	require.NoError(r.t, err)
+	r.logger.Tracef("removing %s\n", digest.Context().RepositoryStr()+"@"+digest.DigestStr())
+	delete(r.images, digest.Context().RepositoryStr()+"@"+digest.DigestStr())
+	delete(r.images, digest.Context().RepositoryStr())
+}
+
 type BundleInfo struct {
 	r          *FakeTestRegistryBuilder
 	Image      v1.Image

--- a/test/helpers/fake_registry.go
+++ b/test/helpers/fake_registry.go
@@ -38,10 +38,11 @@ type FakeTestRegistryBuilder struct {
 	server *httptest.Server
 	t      *testing.T
 	auth   authn.Authenticator
+	logger *Logger
 }
 
-func NewFakeRegistry(t *testing.T) *FakeTestRegistryBuilder {
-	r := &FakeTestRegistryBuilder{images: map[string]*ImageOrImageIndexWithTarPath{}, t: t}
+func NewFakeRegistry(t *testing.T, logger *Logger) *FakeTestRegistryBuilder {
+	r := &FakeTestRegistryBuilder{images: map[string]*ImageOrImageIndexWithTarPath{}, t: t, logger: logger}
 	r.server = httptest.NewServer(regregistry.New(regregistry.Logger(log.New(io.Discard, "", 0))))
 
 	return r
@@ -57,6 +58,7 @@ func (r *FakeTestRegistryBuilder) Build() registry.Registry {
 		auth := regremote.WithAuth(r.auth)
 
 		if val.Image != nil {
+			r.logger.Tracef("build: creating image on registry: %s\n", fmt.Sprintf("%s/%s", u.Host, imageRef))
 			err = regremote.Write(imageRefWithTestRegistry, val.Image, regremote.WithNondistributable, auth)
 			assert.NoError(r.t, err)
 			err = regremote.Tag(imageRefWithTestRegistry.Context().Tag("latest"), val.Image, auth)
@@ -64,6 +66,7 @@ func (r *FakeTestRegistryBuilder) Build() registry.Registry {
 		}
 
 		if val.ImageIndex != nil {
+			r.logger.Tracef("build: creating index on registry: %s\n", fmt.Sprintf("%s/%s", u.Host, imageRef))
 			err = regremote.WriteIndex(imageRefWithTestRegistry, val.ImageIndex, regremote.WithNondistributable, auth)
 			assert.NoError(r.t, err)
 			err = regremote.Tag(imageRefWithTestRegistry.Context().Tag("latest"), val.ImageIndex, auth)
@@ -185,7 +188,8 @@ func (r *FakeTestRegistryBuilder) WithBundleFromPath(bundleName string, path str
 	digest, err := bundle.Digest()
 	assert.NoError(r.t, err)
 
-	return BundleInfo{r, bundle, bundleName, path, digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
+	return BundleInfo{r, bundle, bundleName, path,
+		digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
 }
 
 func (r *FakeTestRegistryBuilder) WithRandomBundle(bundleName string) BundleInfo {
@@ -203,8 +207,12 @@ func (r *FakeTestRegistryBuilder) WithRandomBundle(bundleName string) BundleInfo
 
 	digest, err := bundle.Digest()
 	assert.NoError(r.t, err)
-
-	return BundleInfo{r, bundle, bundleName, "", digest.String(), r.ReferenceOnTestServer(bundleName + "@" + digest.String())}
+	imgName, err := name.ParseReference(bundleName)
+	require.NoError(r.t, err)
+	bundleRef := r.ReferenceOnTestServer(imgName.Context().RepositoryStr() + "@" + digest.String())
+	r.logger.Tracef("created bundle %s\n", bundleRef)
+	return BundleInfo{r, bundle, bundleName, "",
+		digest.String(), bundleRef}
 }
 
 func (r *FakeTestRegistryBuilder) WithImageFromPath(imageNameFromTest string, path string, labels map[string]string) *ImageOrImageIndexWithTarPath {
@@ -221,7 +229,9 @@ func (r *FakeTestRegistryBuilder) WithRandomImage(imageNameFromTest string) *Ima
 	img, err := random.Image(500, 3)
 	require.NoError(r.t, err, "create image from tar")
 
-	return r.updateState(imageNameFromTest, img, nil, "")
+	newImg := r.updateState(imageNameFromTest, img, nil, "")
+	r.logger.Tracef("created image %s\n", newImg.RefDigest)
+	return newImg
 }
 
 func (r *FakeTestRegistryBuilder) WithImage(imageNameFromTest string, image v1.Image) *ImageOrImageIndexWithTarPath {
@@ -229,13 +239,43 @@ func (r *FakeTestRegistryBuilder) WithImage(imageNameFromTest string, image v1.I
 }
 
 func (r *FakeTestRegistryBuilder) CopyImage(img ImageOrImageIndexWithTarPath, to string) *ImageOrImageIndexWithTarPath {
+	r.logger.Tracef("copy image %s to %s\n", img.RefDigest, to)
 	return r.updateState(to, img.Image, nil, "")
+}
+
+func (r *FakeTestRegistryBuilder) CopyFromImageRef(imageRef, to string) *ImageOrImageIndexWithTarPath {
+	digest, err := name.NewDigest(imageRef)
+	require.NoError(r.t, err)
+	r.logger.Tracef("copying image %s to %s\n", imageRef, to)
+	img, ok := r.images[digest.Context().RepositoryStr()+"@"+digest.DigestStr()]
+	require.True(r.t, ok)
+	return r.updateState(to, img.Image, nil, "")
+}
+
+func (r *FakeTestRegistryBuilder) CopyAllImagesFromRepo(imageRef, to string) {
+	digest, err := name.NewDigest(imageRef)
+	require.NoError(r.t, err)
+	var imgsToCopy []*ImageOrImageIndexWithTarPath
+	for repo, img := range r.images {
+		parts := strings.Split(repo, "@")
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[0] == digest.Context().RepositoryStr() {
+			imgsToCopy = append(imgsToCopy, img)
+		}
+	}
+	for _, img := range imgsToCopy {
+		r.logger.Tracef("copying image %s to %s\n", img.RefDigest, strings.Split(to, "@")[0])
+		r.updateState(to, img.Image, nil, "")
+	}
 }
 
 func (r *FakeTestRegistryBuilder) CopyBundleImage(bundleInfo BundleInfo, to string) BundleInfo {
 	newBundle := *r.images[bundleInfo.BundleName]
-	r.updateState(to, newBundle.Image, nil, "")
-	return BundleInfo{r, newBundle.Image, to, "", bundleInfo.Digest, bundleInfo.RefDigest}
+	r.updateState(to, bundleInfo.Image, nil, "")
+	return BundleInfo{r, newBundle.Image, to, "",
+		newBundle.Digest, newBundle.RefDigest}
 }
 
 func (r *FakeTestRegistryBuilder) WithARandomImageIndex(imageName string) *ImageOrImageIndexWithTarPath {

--- a/test/helpers/image_factory.go
+++ b/test/helpers/image_factory.go
@@ -66,6 +66,19 @@ func (i *ImageFactory) PushSimpleAppImageWithRandomFile(imgpkg Imgpkg, imgRef st
 	return fmt.Sprintf("@%s", ExtractDigest(i.T, out))
 }
 
+func (i *ImageFactory) PushSimpleAppImageWithRandomFileWithAuth(imgpkg Imgpkg, imgRef string, host, username, password string) string {
+	i.T.Helper()
+	imgDir := i.Assets.CreateAndCopySimpleApp("simple-image")
+	// Add file to ensure we have a different digest
+	i.Assets.AddFileToFolder(filepath.Join(imgDir, "random-file.txt"), randString(500))
+
+	out, err := imgpkg.RunWithOpts([]string{"push", "--tty", "-i", imgRef, "-f", imgDir}, RunOpts{
+		EnvVars: []string{"IMGPKG_REGISTRY_HOSTNAME=" + host, "IMGPKG_REGISTRY_USERNAME=" + username, "IMGPKG_REGISTRY_PASSWORD=" + password},
+	})
+	require.NoError(i.T, err)
+	return fmt.Sprintf("@%s", ExtractDigest(i.T, out))
+}
+
 func (i *ImageFactory) PushImageWithLayerSize(imgRef string, size int64) string {
 	imageRef, err := name.ParseReference(imgRef, name.WeakValidation)
 	require.NoError(i.T, err)

--- a/test/helpers/logger.go
+++ b/test/helpers/logger.go
@@ -9,7 +9,16 @@ import (
 	"time"
 )
 
-type Logger struct{}
+type LogLevel int
+
+const (
+	LogTrace LogLevel = iota
+	LogDebug LogLevel = iota
+)
+
+type Logger struct {
+	LogLevel LogLevel
+}
 
 func (l Logger) Section(msg string, f func()) {
 	fmt.Printf("==> %s\n", msg)
@@ -18,6 +27,12 @@ func (l Logger) Section(msg string, f func()) {
 
 func (l Logger) Debugf(msg string, args ...interface{}) {
 	fmt.Printf(msg, args...)
+}
+
+func (l Logger) Tracef(msg string, args ...interface{}) {
+	if l.LogLevel == LogTrace {
+		fmt.Printf(msg, args...)
+	}
 }
 
 func init() {


### PR DESCRIPTION
Change the way the images are collected from all the bundles.
Previously we were relying on `ImageRef.Image` to check if the Image was a Bundle and to retrieve the Images from it. This is not correct since that location might be behind a private repository, `imgpkg` should try to check if the bundle was copied to the current location or not and should use that information to try to read the needed information.

Relates to #146 