### PR TITLE
Multi write panic progress bar

### DIFF
--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -88,7 +88,7 @@ func (c *CopyOptions) Run() error {
 	prefixedLogger := logger.NewPrefixedWriter("copy | ")
 	levelLogger := logger.NewLevelLogger(util.LogWarn, prefixedLogger)
 
-	imagesUploaderLogger := logger.NewProgressBar("copy | ", "done uploading images")
+	imagesUploaderLogger := logger.NewProgressBar(levelLogger, "done uploading images", "Error uploading images")
 	regWithProgress := registry.NewRegistryWithProgress(reg, imagesUploaderLogger)
 
 	switch {

--- a/pkg/imgpkg/cmd/copy_repo_src.go
+++ b/pkg/imgpkg/cmd/copy_repo_src.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagetar"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/k14s/imgpkg/pkg/imgpkg/plainimage"
+	"github.com/k14s/imgpkg/pkg/imgpkg/util"
 )
 
 type SignatureRetriever interface {
@@ -26,7 +27,7 @@ type CopyRepoSrc struct {
 	LockInputFlags          LockInputFlags
 	IncludeNonDistributable bool
 	Concurrency             int
-	logger                  Logger
+	logger                  util.LoggerWithLevels
 	imageSet                ctlimgset.ImageSet
 	tarImageSet             ctlimgset.TarImageSet
 	registry                ctlimgset.ImagesReaderWriter

--- a/pkg/imgpkg/cmd/copy_repo_src_test.go
+++ b/pkg/imgpkg/cmd/copy_repo_src_test.go
@@ -29,13 +29,15 @@ var stdOut *bytes.Buffer
 
 func TestMain(m *testing.M) {
 	stdOut = bytes.NewBufferString("")
-	logger := util.NewLogger(stdOut).NewPrefixedWriter("test|    ")
-	imageSet := imageset.NewImageSet(1, logger)
+	logger := util.NewLogger(stdOut)
+	prefixedLogger := logger.NewPrefixedWriter("test | ")
+	levelLogger := logger.NewLevelLogger(util.LogWarn, prefixedLogger)
+	imageSet := imageset.NewImageSet(1, prefixedLogger)
 
 	subject = CopyRepoSrc{
-		logger:             logger,
+		logger:             levelLogger,
 		imageSet:           imageSet,
-		tarImageSet:        imageset.NewTarImageSet(imageSet, 1, logger),
+		tarImageSet:        imageset.NewTarImageSet(imageSet, 1, prefixedLogger),
 		Concurrency:        1,
 		signatureRetriever: &fakeSignatureRetriever{},
 	}

--- a/pkg/imgpkg/imageset/image_set.go
+++ b/pkg/imgpkg/imageset/image_set.go
@@ -22,7 +22,7 @@ type Logger interface {
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ImagesReaderWriter
 type ImagesReaderWriter interface {
 	ctlimg.ImagesMetadata
-	MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int, opts ...regremote.Option) error
+	MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int, updatesCh chan regv1.Update) error
 	WriteImage(regname.Reference, regv1.Image) error
 	WriteIndex(regname.Reference, regv1.ImageIndex) error
 	WriteTag(regname.Tag, regremote.Taggable) error
@@ -111,7 +111,7 @@ func (i *ImageSet) Import(imgOrIndexes []imagedesc.ImageOrIndex,
 		return nil, err
 	}
 
-	err = registry.MultiWrite(imageOrIndexesToWrite, i.concurrency)
+	err = registry.MultiWrite(imageOrIndexesToWrite, i.concurrency, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imgpkg/imageset/image_set.go
+++ b/pkg/imgpkg/imageset/image_set.go
@@ -22,7 +22,7 @@ type Logger interface {
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ImagesReaderWriter
 type ImagesReaderWriter interface {
 	ctlimg.ImagesMetadata
-	MultiWrite(map[regname.Reference]regremote.Taggable, int) error
+	MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int, opts ...regremote.Option) error
 	WriteImage(regname.Reference, regv1.Image) error
 	WriteIndex(regname.Reference, regv1.ImageIndex) error
 	WriteTag(regname.Tag, regremote.Taggable) error

--- a/pkg/imgpkg/imageset/imagesetfakes/fake_images_reader_writer.go
+++ b/pkg/imgpkg/imageset/imagesetfakes/fake_images_reader_writer.go
@@ -76,12 +76,12 @@ type FakeImagesReaderWriter struct {
 		result1 v1.ImageIndex
 		result2 error
 	}
-	MultiWriteStub        func(map[name.Reference]remote.Taggable, int, ...remote.Option) error
+	MultiWriteStub        func(map[name.Reference]remote.Taggable, int, chan v1.Update) error
 	multiWriteMutex       sync.RWMutex
 	multiWriteArgsForCall []struct {
 		arg1 map[name.Reference]remote.Taggable
 		arg2 int
-		arg3 []remote.Option
+		arg3 chan v1.Update
 	}
 	multiWriteReturns struct {
 		result1 error
@@ -454,20 +454,20 @@ func (fake *FakeImagesReaderWriter) IndexReturnsOnCall(i int, result1 v1.ImageIn
 	}{result1, result2}
 }
 
-func (fake *FakeImagesReaderWriter) MultiWrite(arg1 map[name.Reference]remote.Taggable, arg2 int, arg3 ...remote.Option) error {
+func (fake *FakeImagesReaderWriter) MultiWrite(arg1 map[name.Reference]remote.Taggable, arg2 int, arg3 chan v1.Update) error {
 	fake.multiWriteMutex.Lock()
 	ret, specificReturn := fake.multiWriteReturnsOnCall[len(fake.multiWriteArgsForCall)]
 	fake.multiWriteArgsForCall = append(fake.multiWriteArgsForCall, struct {
 		arg1 map[name.Reference]remote.Taggable
 		arg2 int
-		arg3 []remote.Option
+		arg3 chan v1.Update
 	}{arg1, arg2, arg3})
 	stub := fake.MultiWriteStub
 	fakeReturns := fake.multiWriteReturns
 	fake.recordInvocation("MultiWrite", []interface{}{arg1, arg2, arg3})
 	fake.multiWriteMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3...)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -481,13 +481,13 @@ func (fake *FakeImagesReaderWriter) MultiWriteCallCount() int {
 	return len(fake.multiWriteArgsForCall)
 }
 
-func (fake *FakeImagesReaderWriter) MultiWriteCalls(stub func(map[name.Reference]remote.Taggable, int, ...remote.Option) error) {
+func (fake *FakeImagesReaderWriter) MultiWriteCalls(stub func(map[name.Reference]remote.Taggable, int, chan v1.Update) error) {
 	fake.multiWriteMutex.Lock()
 	defer fake.multiWriteMutex.Unlock()
 	fake.MultiWriteStub = stub
 }
 
-func (fake *FakeImagesReaderWriter) MultiWriteArgsForCall(i int) (map[name.Reference]remote.Taggable, int, []remote.Option) {
+func (fake *FakeImagesReaderWriter) MultiWriteArgsForCall(i int) (map[name.Reference]remote.Taggable, int, chan v1.Update) {
 	fake.multiWriteMutex.RLock()
 	defer fake.multiWriteMutex.RUnlock()
 	argsForCall := fake.multiWriteArgsForCall[i]

--- a/pkg/imgpkg/imageset/imagesetfakes/fake_images_reader_writer.go
+++ b/pkg/imgpkg/imageset/imagesetfakes/fake_images_reader_writer.go
@@ -37,19 +37,6 @@ type FakeImagesReaderWriter struct {
 		result1 string
 		result2 error
 	}
-	GenericStub        func(name.Reference) (v1.Descriptor, error)
-	genericMutex       sync.RWMutex
-	genericArgsForCall []struct {
-		arg1 name.Reference
-	}
-	genericReturns struct {
-		result1 v1.Descriptor
-		result2 error
-	}
-	genericReturnsOnCall map[int]struct {
-		result1 v1.Descriptor
-		result2 error
-	}
 	GetStub        func(name.Reference) (*remote.Descriptor, error)
 	getMutex       sync.RWMutex
 	getArgsForCall []struct {
@@ -89,11 +76,12 @@ type FakeImagesReaderWriter struct {
 		result1 v1.ImageIndex
 		result2 error
 	}
-	MultiWriteStub        func(map[name.Reference]remote.Taggable, int) error
+	MultiWriteStub        func(map[name.Reference]remote.Taggable, int, ...remote.Option) error
 	multiWriteMutex       sync.RWMutex
 	multiWriteArgsForCall []struct {
 		arg1 map[name.Reference]remote.Taggable
 		arg2 int
+		arg3 []remote.Option
 	}
 	multiWriteReturns struct {
 		result1 error
@@ -270,70 +258,6 @@ func (fake *FakeImagesReaderWriter) FirstImageExistsReturnsOnCall(i int, result1
 	}
 	fake.firstImageExistsReturnsOnCall[i] = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImagesReaderWriter) Generic(arg1 name.Reference) (v1.Descriptor, error) {
-	fake.genericMutex.Lock()
-	ret, specificReturn := fake.genericReturnsOnCall[len(fake.genericArgsForCall)]
-	fake.genericArgsForCall = append(fake.genericArgsForCall, struct {
-		arg1 name.Reference
-	}{arg1})
-	stub := fake.GenericStub
-	fakeReturns := fake.genericReturns
-	fake.recordInvocation("Generic", []interface{}{arg1})
-	fake.genericMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeImagesReaderWriter) GenericCallCount() int {
-	fake.genericMutex.RLock()
-	defer fake.genericMutex.RUnlock()
-	return len(fake.genericArgsForCall)
-}
-
-func (fake *FakeImagesReaderWriter) GenericCalls(stub func(name.Reference) (v1.Descriptor, error)) {
-	fake.genericMutex.Lock()
-	defer fake.genericMutex.Unlock()
-	fake.GenericStub = stub
-}
-
-func (fake *FakeImagesReaderWriter) GenericArgsForCall(i int) name.Reference {
-	fake.genericMutex.RLock()
-	defer fake.genericMutex.RUnlock()
-	argsForCall := fake.genericArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeImagesReaderWriter) GenericReturns(result1 v1.Descriptor, result2 error) {
-	fake.genericMutex.Lock()
-	defer fake.genericMutex.Unlock()
-	fake.GenericStub = nil
-	fake.genericReturns = struct {
-		result1 v1.Descriptor
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImagesReaderWriter) GenericReturnsOnCall(i int, result1 v1.Descriptor, result2 error) {
-	fake.genericMutex.Lock()
-	defer fake.genericMutex.Unlock()
-	fake.GenericStub = nil
-	if fake.genericReturnsOnCall == nil {
-		fake.genericReturnsOnCall = make(map[int]struct {
-			result1 v1.Descriptor
-			result2 error
-		})
-	}
-	fake.genericReturnsOnCall[i] = struct {
-		result1 v1.Descriptor
 		result2 error
 	}{result1, result2}
 }
@@ -530,19 +454,20 @@ func (fake *FakeImagesReaderWriter) IndexReturnsOnCall(i int, result1 v1.ImageIn
 	}{result1, result2}
 }
 
-func (fake *FakeImagesReaderWriter) MultiWrite(arg1 map[name.Reference]remote.Taggable, arg2 int) error {
+func (fake *FakeImagesReaderWriter) MultiWrite(arg1 map[name.Reference]remote.Taggable, arg2 int, arg3 ...remote.Option) error {
 	fake.multiWriteMutex.Lock()
 	ret, specificReturn := fake.multiWriteReturnsOnCall[len(fake.multiWriteArgsForCall)]
 	fake.multiWriteArgsForCall = append(fake.multiWriteArgsForCall, struct {
 		arg1 map[name.Reference]remote.Taggable
 		arg2 int
-	}{arg1, arg2})
+		arg3 []remote.Option
+	}{arg1, arg2, arg3})
 	stub := fake.MultiWriteStub
 	fakeReturns := fake.multiWriteReturns
-	fake.recordInvocation("MultiWrite", []interface{}{arg1, arg2})
+	fake.recordInvocation("MultiWrite", []interface{}{arg1, arg2, arg3})
 	fake.multiWriteMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
@@ -556,17 +481,17 @@ func (fake *FakeImagesReaderWriter) MultiWriteCallCount() int {
 	return len(fake.multiWriteArgsForCall)
 }
 
-func (fake *FakeImagesReaderWriter) MultiWriteCalls(stub func(map[name.Reference]remote.Taggable, int) error) {
+func (fake *FakeImagesReaderWriter) MultiWriteCalls(stub func(map[name.Reference]remote.Taggable, int, ...remote.Option) error) {
 	fake.multiWriteMutex.Lock()
 	defer fake.multiWriteMutex.Unlock()
 	fake.MultiWriteStub = stub
 }
 
-func (fake *FakeImagesReaderWriter) MultiWriteArgsForCall(i int) (map[name.Reference]remote.Taggable, int) {
+func (fake *FakeImagesReaderWriter) MultiWriteArgsForCall(i int) (map[name.Reference]remote.Taggable, int, []remote.Option) {
 	fake.multiWriteMutex.RLock()
 	defer fake.multiWriteMutex.RUnlock()
 	argsForCall := fake.multiWriteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeImagesReaderWriter) MultiWriteReturns(result1 error) {
@@ -785,8 +710,6 @@ func (fake *FakeImagesReaderWriter) Invocations() map[string][][]interface{} {
 	defer fake.digestMutex.RUnlock()
 	fake.firstImageExistsMutex.RLock()
 	defer fake.firstImageExistsMutex.RUnlock()
-	fake.genericMutex.RLock()
-	defer fake.genericMutex.RUnlock()
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
 	fake.imageMutex.RLock()

--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -107,10 +107,23 @@ func (r Registry) Image(ref regname.Reference) (regv1.Image, error) {
 	return regremote.Image(overriddenRef, r.opts...)
 }
 
-func (r Registry) MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int, opts ...regremote.Option) error {
+func (r Registry) MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int, updatesCh chan regv1.Update) error {
 	return util.Retry(func() error {
-		lOpts := append(append([]regremote.Option{}, r.opts...), opts...)
-		return regremote.MultiWrite(imageOrIndexesToUpload, append(lOpts, regremote.WithJobs(concurrency))...)
+		lOpts := append(append([]regremote.Option{}, r.opts...), regremote.WithJobs(concurrency))
+
+		// Only use the registry with progress reporting if a channel is provided to this method
+		if updatesCh != nil {
+			uploadProgress := make(chan regv1.Update)
+			lOpts = append(lOpts, regremote.WithProgress(uploadProgress))
+
+			go func() {
+				for update := range uploadProgress {
+					updatesCh <- update
+				}
+			}()
+		}
+
+		return regremote.MultiWrite(imageOrIndexesToUpload, lOpts...)
 	})
 }
 

--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -107,9 +107,10 @@ func (r Registry) Image(ref regname.Reference) (regv1.Image, error) {
 	return regremote.Image(overriddenRef, r.opts...)
 }
 
-func (r Registry) MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int) error {
+func (r Registry) MultiWrite(imageOrIndexesToUpload map[regname.Reference]regremote.Taggable, concurrency int, opts ...regremote.Option) error {
 	return util.Retry(func() error {
-		return regremote.MultiWrite(imageOrIndexesToUpload, append(r.opts, regremote.WithJobs(concurrency))...)
+		lOpts := append(append([]regremote.Option{}, r.opts...), opts...)
+		return regremote.MultiWrite(imageOrIndexesToUpload, append(lOpts, regremote.WithJobs(concurrency))...)
 	})
 }
 

--- a/pkg/imgpkg/registry/with_progress.go
+++ b/pkg/imgpkg/registry/with_progress.go
@@ -39,12 +39,12 @@ func (w WithProgress) FirstImageExists(digests []string) (string, error) {
 	return w.delegate.FirstImageExists(digests)
 }
 
-func (w *WithProgress) MultiWrite(imageOrIndexesToUpload map[regname.Reference]remote.Taggable, concurrency int, opts ...remote.Option) error {
+func (w *WithProgress) MultiWrite(imageOrIndexesToUpload map[regname.Reference]remote.Taggable, concurrency int, _ chan regv1.Update) error {
 	uploadProgress := make(chan regv1.Update)
 	w.logger.Start(uploadProgress)
 	defer w.logger.End()
 
-	return w.delegate.MultiWrite(imageOrIndexesToUpload, concurrency, append(append([]remote.Option{}, opts...), remote.WithProgress(uploadProgress))...)
+	return w.delegate.MultiWrite(imageOrIndexesToUpload, concurrency, uploadProgress)
 }
 
 func (w WithProgress) WriteImage(reference regname.Reference, image regv1.Image) error {

--- a/pkg/imgpkg/registry/with_progress.go
+++ b/pkg/imgpkg/registry/with_progress.go
@@ -1,0 +1,60 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	regname "github.com/google/go-containerregistry/pkg/name"
+	regv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/k14s/imgpkg/pkg/imgpkg/util"
+)
+
+func NewRegistryWithProgress(reg Registry, logger util.ProgressLogger) *WithProgress {
+	return &WithProgress{delegate: reg, logger: logger}
+}
+
+type WithProgress struct {
+	delegate Registry
+	logger   util.ProgressLogger
+}
+
+func (w WithProgress) Get(reference regname.Reference) (*remote.Descriptor, error) {
+	return w.delegate.Get(reference)
+}
+
+func (w WithProgress) Digest(reference regname.Reference) (regv1.Hash, error) {
+	return w.delegate.Digest(reference)
+}
+
+func (w WithProgress) Index(reference regname.Reference) (regv1.ImageIndex, error) {
+	return w.delegate.Index(reference)
+}
+
+func (w WithProgress) Image(reference regname.Reference) (regv1.Image, error) {
+	return w.delegate.Image(reference)
+}
+
+func (w WithProgress) FirstImageExists(digests []string) (string, error) {
+	return w.delegate.FirstImageExists(digests)
+}
+
+func (w *WithProgress) MultiWrite(imageOrIndexesToUpload map[regname.Reference]remote.Taggable, concurrency int, opts ...remote.Option) error {
+	uploadProgress := make(chan regv1.Update)
+	w.logger.Start(uploadProgress)
+	defer w.logger.End()
+
+	return w.delegate.MultiWrite(imageOrIndexesToUpload, concurrency, append(append([]remote.Option{}, opts...), remote.WithProgress(uploadProgress))...)
+}
+
+func (w WithProgress) WriteImage(reference regname.Reference, image regv1.Image) error {
+	return w.delegate.WriteImage(reference, image)
+}
+
+func (w WithProgress) WriteIndex(reference regname.Reference, index regv1.ImageIndex) error {
+	return w.delegate.WriteIndex(reference, index)
+}
+
+func (w WithProgress) WriteTag(tag regname.Tag, taggable remote.Taggable) error {
+	return w.delegate.WriteTag(tag, taggable)
+}

--- a/pkg/imgpkg/util/level_logger.go
+++ b/pkg/imgpkg/util/level_logger.go
@@ -5,7 +5,14 @@ package util
 
 type LogLevel int
 
+type Logger interface {
+	Logf(msg string, args ...interface{})
+}
+
 type LoggerWithLevels interface {
+	Logger
+
+	Errorf(msg string, args ...interface{})
 	Warnf(msg string, args ...interface{})
 	Debugf(msg string, args ...interface{})
 	Tracef(msg string, args ...interface{})
@@ -17,7 +24,7 @@ const (
 	LogWarn  LogLevel = iota
 )
 
-func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger *LoggerPrefixWriter) *LoggerLevelWriter {
+func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger Logger) *LoggerLevelWriter {
 	return &LoggerLevelWriter{
 		LogLevel: level,
 		logger:   logger,
@@ -26,23 +33,31 @@ func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger *LoggerPrefixWriter)
 
 type LoggerLevelWriter struct {
 	LogLevel LogLevel
-	logger   *LoggerPrefixWriter
+	logger   Logger
+}
+
+func (l LoggerLevelWriter) Errorf(msg string, args ...interface{}) {
+	l.Logf("Error: "+msg, args...)
 }
 
 func (l LoggerLevelWriter) Warnf(msg string, args ...interface{}) {
 	if l.LogLevel <= LogWarn {
-		l.logger.WriteStr("Warning: "+msg, args...)
+		l.Logf("Warning: "+msg, args...)
 	}
+}
+
+func (l LoggerLevelWriter) Logf(msg string, args ...interface{}) {
+	l.logger.Logf(msg, args...)
 }
 
 func (l LoggerLevelWriter) Debugf(msg string, args ...interface{}) {
 	if l.LogLevel <= LogDebug {
-		l.logger.WriteStr(msg, args...)
+		l.Logf(msg, args...)
 	}
 }
 
 func (l LoggerLevelWriter) Tracef(msg string, args ...interface{}) {
 	if l.LogLevel == LogTrace {
-		l.logger.WriteStr(msg, args...)
+		l.Logf(msg, args...)
 	}
 }

--- a/pkg/imgpkg/util/level_logger.go
+++ b/pkg/imgpkg/util/level_logger.go
@@ -1,0 +1,48 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+type LogLevel int
+
+type LoggerWithLevels interface {
+	Warnf(msg string, args ...interface{})
+	Debugf(msg string, args ...interface{})
+	Tracef(msg string, args ...interface{})
+}
+
+const (
+	LogTrace LogLevel = iota
+	LogDebug LogLevel = iota
+	LogWarn  LogLevel = iota
+)
+
+func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger *LoggerPrefixWriter) *LoggerLevelWriter {
+	return &LoggerLevelWriter{
+		LogLevel: level,
+		logger:   logger,
+	}
+}
+
+type LoggerLevelWriter struct {
+	LogLevel LogLevel
+	logger   *LoggerPrefixWriter
+}
+
+func (l LoggerLevelWriter) Warnf(msg string, args ...interface{}) {
+	if l.LogLevel <= LogWarn {
+		l.logger.WriteStr("Warning: "+msg, args...)
+	}
+}
+
+func (l LoggerLevelWriter) Debugf(msg string, args ...interface{}) {
+	if l.LogLevel <= LogDebug {
+		l.logger.WriteStr(msg, args...)
+	}
+}
+
+func (l LoggerLevelWriter) Tracef(msg string, args ...interface{}) {
+	if l.LogLevel == LogTrace {
+		l.logger.WriteStr(msg, args...)
+	}
+}

--- a/pkg/imgpkg/util/level_logger_test.go
+++ b/pkg/imgpkg/util/level_logger_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/k14s/imgpkg/pkg/imgpkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelLogger(t *testing.T) {
+	t.Run("when log level is set to warn only write the warning message", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		logger := util.NewLogger(&buf)
+		subject := logger.NewLevelLogger(util.LogWarn, logger.NewPrefixedWriter(""))
+		subject.Warnf("warning message\n")
+		subject.Debugf("debug message\n")
+		subject.Tracef("trace message\n")
+
+		require.Equal(t, "Warning: warning message\n", buf.String())
+	})
+
+	t.Run("when log level is set to debug only write the warning and debug message", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		logger := util.NewLogger(&buf)
+		subject := logger.NewLevelLogger(util.LogDebug, logger.NewPrefixedWriter(""))
+		subject.Warnf("warning message\n")
+		subject.Debugf("debug message\n")
+		subject.Tracef("trace message\n")
+
+		require.Equal(t, "Warning: warning message\ndebug message\n", buf.String())
+	})
+
+	t.Run("when log level is set to trace only writes all messages", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		logger := util.NewLogger(&buf)
+		subject := logger.NewLevelLogger(util.LogTrace, logger.NewPrefixedWriter(""))
+		subject.Warnf("warning message\n")
+		subject.Debugf("debug message\n")
+		subject.Tracef("trace message\n")
+
+		require.Equal(t, "Warning: warning message\ndebug message\ntrace message\n", buf.String())
+	})
+}

--- a/pkg/imgpkg/util/prefixed_logger.go
+++ b/pkg/imgpkg/util/prefixed_logger.go
@@ -29,6 +29,10 @@ type LoggerPrefixWriter struct {
 	writerLock *sync.Mutex
 }
 
+func (w *LoggerPrefixWriter) Logf(msg string, args ...interface{}) {
+	w.WriteStr(msg, args...)
+}
+
 func (w *LoggerPrefixWriter) Write(data []byte) (int, error) {
 	newData := make([]byte, len(data))
 	copy(newData, data)

--- a/pkg/imgpkg/util/progress_logger.go
+++ b/pkg/imgpkg/util/progress_logger.go
@@ -28,11 +28,11 @@ func (l ImgpkgLogger) NewProgressBar(prefix, finalMessage string) ProgressLogger
 }
 
 type ProgressBarLogger struct {
-	ctx            context.Context
-	cancelFunc     context.CancelFunc
-	bar            *pb.ProgressBar
-	prefix         string
-	finalMessage   string
+	ctx          context.Context
+	cancelFunc   context.CancelFunc
+	bar          *pb.ProgressBar
+	prefix       string
+	finalMessage string
 }
 
 func (l *ProgressBarLogger) Start(progressChan <-chan regv1.Update) {
@@ -64,10 +64,10 @@ func (l *ProgressBarLogger) End() {
 }
 
 type ProgressBarNoTTYLogger struct {
-	ctx            context.Context
-	cancelFunc     context.CancelFunc
-	prefix         string
-	finalMessage   string
+	ctx          context.Context
+	cancelFunc   context.CancelFunc
+	prefix       string
+	finalMessage string
 }
 
 func (l *ProgressBarNoTTYLogger) Start(progressChan <-chan regv1.Update) {

--- a/test/helpers/logger.go
+++ b/test/helpers/logger.go
@@ -25,7 +25,15 @@ func (l Logger) Section(msg string, f func()) {
 	f()
 }
 
+func (l Logger) Errorf(msg string, args ...interface{}) {
+	fmt.Printf(msg, args...)
+}
+
 func (l Logger) Warnf(msg string, args ...interface{}) {
+	fmt.Printf(msg, args...)
+}
+
+func (l Logger) Logf(msg string, args ...interface{}) {
 	fmt.Printf(msg, args...)
 }
 

--- a/test/helpers/logger.go
+++ b/test/helpers/logger.go
@@ -25,6 +25,10 @@ func (l Logger) Section(msg string, f func()) {
 	f()
 }
 
+func (l Logger) Warnf(msg string, args ...interface{}) {
+	fmt.Printf(msg, args...)
+}
+
 func (l Logger) Debugf(msg string, args ...interface{}) {
 	fmt.Printf(msg, args...)
 }


### PR DESCRIPTION
Solve the problem of retries when displaying the progress bar

Go-containerregistry required the called to provide a new channel per invocation, in order to achieve that this PR creates a wrapper around our Registry struct that will enable us to provide this channel as an implementation detail of the Registry and not something that the copy command needs to manage.

With this PR we are also including the LoggerWithLevels that will enable us to have more logging in `imgpkg`

Display any error that go-containerregistry library might surface while trying to upload images

Related to #155 