### PR TITLE
Fix oci locations setting images to null

### DIFF
--- a/pkg/imgpkg/bundle/bundle.go
+++ b/pkg/imgpkg/bundle/bundle.go
@@ -58,6 +58,15 @@ func (o *Bundle) addImageRefs(refs ...ImageRef) {
 
 func (o *Bundle) imageRef(imageDigest string) (ImageRef, bool) {
 	ref, found := o.imagesRef[imageDigest]
+	if !found {
+		for _, imgRef := range o.imagesRef {
+			for _, loc := range imgRef.Locations() {
+				if loc == imageDigest {
+					return imgRef, true
+				}
+			}
+		}
+	}
 	return ref, found
 }
 
@@ -86,6 +95,10 @@ func (o *Bundle) NoteCopy(processedImages *imageset.ProcessedImages, reg ImagesM
 		if image.UnprocessedImageRef.DigestRef == o.DigestRef() {
 			bundleProcessedImage = image
 		}
+	}
+
+	if len(locationsCfg.Images) != len(o.imagesRef) {
+		panic(fmt.Sprintf("Expected: %d images to be written to Location OCI. Actual: %d were written", len(o.imagesRef), len(locationsCfg.Images)))
 	}
 
 	destinationRef, err := regname.NewDigest(bundleProcessedImage.DigestRef)

--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -35,7 +35,6 @@ func (o *Bundle) AllImagesRefs(concurrency int, logger util.LoggerWithLevels) ([
 			if !found {
 				panic(fmt.Sprintf("Internal inconsistency: The Image '%s' cannot be found in the total list of images", ref.Image))
 			}
-			imgRef = imgRef.DeepCopy()
 			bundle.addImageRefs(imgRef)
 		}
 	}
@@ -61,7 +60,6 @@ func (o *Bundle) buildAllImagesLock(throttleReq *util.Throttle, processedImgs *p
 	mutex := &sync.Mutex{}
 
 	for _, image := range imageRefsToProcess.ImageRefs() {
-		image = image.DeepCopy()
 		o.addImageRefs(image)
 
 		if skip := processedImgs.CheckAndAddImage(image.Image); skip {

--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -35,7 +35,7 @@ func (o *Bundle) AllImagesRefs(concurrency int, logger util.LoggerWithLevels) ([
 			if !found {
 				panic(fmt.Sprintf("Internal inconsistency: The Image '%s' cannot be found in the total list of images", ref.Image))
 			}
-
+			imgRef = imgRef.DeepCopy()
 			bundle.addImageRefs(imgRef)
 		}
 	}
@@ -61,6 +61,7 @@ func (o *Bundle) buildAllImagesLock(throttleReq *util.Throttle, processedImgs *p
 	mutex := &sync.Mutex{}
 
 	for _, image := range imageRefsToProcess.ImageRefs() {
+		image = image.DeepCopy()
 		o.addImageRefs(image)
 
 		if skip := processedImgs.CheckAndAddImage(image.Image); skip {

--- a/pkg/imgpkg/lockconfig/images_lock.go
+++ b/pkg/imgpkg/lockconfig/images_lock.go
@@ -58,6 +58,17 @@ func NewImagesLockFromBytes(data []byte) (ImagesLock, error) {
 		return lock, fmt.Errorf("Validating images lock: %s", err)
 	}
 
+	// Update the image lock file to use a fully qualified name
+	// i.e. if a user provides ubuntu (short hand for library/ubuntu) in the ImageLock file,
+	// downstream processing will fail when comparing if images match.
+	for i, img := range lock.Images {
+		parsedImageRefName, err := regname.NewDigest(img.Image)
+		if err != nil {
+			return lock, err
+		}
+		lock.Images[i].Image = parsedImageRefName.Name()
+	}
+
 	return lock, nil
 }
 

--- a/pkg/imgpkg/lockconfig/images_lock.go
+++ b/pkg/imgpkg/lockconfig/images_lock.go
@@ -64,7 +64,7 @@ func NewImagesLockFromBytes(data []byte) (ImagesLock, error) {
 	for i, img := range lock.Images {
 		parsedImageRefName, err := regname.NewDigest(img.Image)
 		if err != nil {
-			return lock, err
+			panic(fmt.Sprintf("Image reference (%s) is in an invalid format: %s", img.Image, err.Error()))
 		}
 		lock.Images[i].Image = parsedImageRefName.Name()
 	}


### PR DESCRIPTION
Attempts to fix: https://github.com/vmware-tanzu/carvel-imgpkg/issues/161

There seems to be a couple of issues:
- Working around issue around setting a bundle image's ref, if that image is missing repo information then the oci locations sets images to null
- when imgpkg copy runs twice, the second time creates an oci location with images set to null

Authored-by: Dennis Leon <leonde@vmware.com>