### PR TITLE
More deterministic push

### DIFF
--- a/pkg/imgpkg/image/tar_image.go
+++ b/pkg/imgpkg/image/tar_image.go
@@ -29,9 +29,15 @@ func (i *TarImage) AsFileImage(labels map[string]string) (*FileImage, error) {
 		return nil, err
 	}
 
-	defer tmpFile.Close()
-
 	err = i.createTarball(tmpFile, i.files)
+	if err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return nil, err
+	}
+
+	// Close file explicitly to make sure all data is flushed
+	err = tmpFile.Close()
 	if err != nil {
 		_ = os.Remove(tmpFile.Name())
 		return nil, err

--- a/pkg/imgpkg/image/tar_image.go
+++ b/pkg/imgpkg/image/tar_image.go
@@ -100,7 +100,6 @@ func (i *TarImage) addDirToTar(relPath string, info os.FileInfo, tarWriter *tar.
 
 	header := &tar.Header{
 		Name:     relPath,
-		Size:     info.Size(),
 		Mode:     0700,        // static
 		ModTime:  time.Time{}, // static
 		Typeflag: tar.TypeDir,

--- a/test/e2e/deterministic_push_test.go
+++ b/test/e2e/deterministic_push_test.go
@@ -20,6 +20,9 @@ func TestDeterministicPush(t *testing.T) {
 	out := imgpkg.Run([]string{"push", "--tty", "-i", env.Image + ":tag1", "-f", assetsPath})
 	tag1Digest := helpers.ExtractDigest(t, out)
 
+	// This expected digest should be the same regardless which OS imgpkg runs on
+	require.Equal(t, tag1Digest, "sha256:ceef30cbdce418efde0284f446df9cec9e535adcd6e1010dad30ddae1dc9367b", "Digest should match in all environments")
+
 	out = imgpkg.Run([]string{"push", "--tty", "-i", env.Image + ":tag2", "-f", assetsPath})
 	tag2Digest := helpers.ExtractDigest(t, out)
 


### PR DESCRIPTION
turns out dir.Size() is not necessary and more importantly not deterministic across different OSes. remove it so that imgpkg push generates same digest everywhere.