### PR TITLE
bug fix: Consider location oci not found with 401 and 403 status code

### DIFF
--- a/pkg/imgpkg/bundle/locations.go
+++ b/pkg/imgpkg/bundle/locations.go
@@ -30,6 +30,12 @@ type LocationsNotFound struct {
 	image string
 }
 
+var imageNotFoundStatusCode = map[int]struct{}{
+	http.StatusNotFound:     {},
+	http.StatusUnauthorized: {},
+	http.StatusForbidden:    {},
+}
+
 func (n LocationsNotFound) Error() string {
 	return fmt.Sprintf("Locations image in %s could not be found", n.image)
 }
@@ -61,7 +67,7 @@ func (r Locations) Fetch(registry image.ImagesMetadata, bundleRef name.Digest) (
 	img, err := registry.Image(locRef)
 	if err != nil {
 		if terr, ok := err.(*transport.Error); ok {
-			if terr.StatusCode == http.StatusNotFound {
+			if _, ok := imageNotFoundStatusCode[terr.StatusCode]; ok {
 				r.logger.Debugf("did not find Locations OCI Image for bundle: %s\n", bundleRef)
 				return ImageLocationsConfig{}, &LocationsNotFound{image: locRef.Name()}
 			}


### PR DESCRIPTION
Attempts to fix: https://github.com/vmware-tanzu/carvel-imgpkg/issues/166

- Allow for registries that return a 401, or 403 when an image doesn't
exist.
-- When checking if the location OCI was present or not, registries that
returned a 401 instead of a 404 would cause the copy command to fail.

- In the case that a registry *does* contain an OCI location image, but
returns a 401 due to invalid credentials, the copy command will fail
down the line when getting the images from the source repo to copy into
the dest repo.

Authored-by: Dennis Leon <leonde@vmware.com>