### PR TITLE
Use the provided version when building binaries

### DIFF
--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -2,8 +2,11 @@
 
 set -e -x -u
 
-LATEST_GIT_TAG=$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+')
-VERSION="${1:-$LATEST_GIT_TAG}"
+function get_latest_git_tag {
+  git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+VERSION="${1:-`get_latest_git_tag`}"
 
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor


### PR DESCRIPTION
- Stop running git describe to figure out the version if it is provided
into the hack/build-binaries.sh script

Co-authored-by: Dennis Leon <leonde@vmware.com>
Co-authored-by: Daniel Helfand <helfand.4@gmail.com>