### PR TITLE
Prevent panic due to concurrent map writes

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -10,6 +10,6 @@ then
     GO=richgo
 fi
 
-$GO test ./pkg/... -test.v $@
+$GO test -race ./pkg/... -test.v $@
 
 echo UNIT SUCCESS

--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -53,7 +53,7 @@ func (o *Bundle) buildAllImagesLock(throttleReq *util.Throttle, processedImgs *p
 		return nil, ImageRefs{}, err
 	}
 
-	processedImageRefs := ImageRefs{}
+	processedImageRefs := NewImageRefs()
 	bundles := []*Bundle{o}
 
 	errChan := make(chan error, len(imageRefsToProcess.ImageRefs()))

--- a/pkg/imgpkg/imageset/unprocessed_image_refs.go
+++ b/pkg/imgpkg/imageset/unprocessed_image_refs.go
@@ -6,6 +6,7 @@ package imageset
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	regname "github.com/google/go-containerregistry/pkg/name"
 )
@@ -17,15 +18,18 @@ type UnprocessedImageRef struct {
 
 type UnprocessedImageRefs struct {
 	imgRefs map[UnprocessedImageRef]struct{}
+	sync.Mutex
 }
 
 func NewUnprocessedImageRefs() *UnprocessedImageRefs {
-	return &UnprocessedImageRefs{map[UnprocessedImageRef]struct{}{}}
+	return &UnprocessedImageRefs{imgRefs: map[UnprocessedImageRef]struct{}{}}
 }
 
 func (i *UnprocessedImageRefs) Add(imgRef UnprocessedImageRef) {
 	imgRef.Validate()
 
+	i.Mutex.Lock()
+	defer i.Mutex.Unlock()
 	i.imgRefs[imgRef] = struct{}{}
 }
 


### PR DESCRIPTION
- uses a pointer on the ImageRefs mutex to avoid linter errors about copying by value
- also add -race when tests are run to help detect race conditions

Authored-by: Dennis Leon <leonde@vmware.com>