### PR TITLE
feat: introduce flag to set the http response timeout value

### DIFF
--- a/pkg/imgpkg/cmd/registry_flags.go
+++ b/pkg/imgpkg/cmd/registry_flags.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"os"
+	"time"
 
 	"github.com/k14s/imgpkg/pkg/imgpkg/registry"
 	"github.com/spf13/cobra"
@@ -19,6 +20,8 @@ type RegistryFlags struct {
 	Password string
 	Token    string
 	Anon     bool
+
+	ResponseHeaderTimeout time.Duration
 }
 
 func (r *RegistryFlags) Set(cmd *cobra.Command) {
@@ -30,6 +33,8 @@ func (r *RegistryFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&r.Password, "registry-password", "", "Set password for auth ($IMGPKG_PASSWORD)")
 	cmd.Flags().StringVar(&r.Token, "registry-token", "", "Set token for auth ($IMGPKG_TOKEN)")
 	cmd.Flags().BoolVar(&r.Anon, "registry-anon", false, "Set anonymous auth ($IMGPKG_ANON)")
+
+	cmd.Flags().DurationVar(&r.ResponseHeaderTimeout, "registry-response-header-timeout", 30*time.Second, "Maximum time to allow a request to wait for a server's response headers from the registry (ms|s|m|h)")
 }
 
 func (r *RegistryFlags) AsRegistryOpts() registry.Opts {
@@ -42,6 +47,8 @@ func (r *RegistryFlags) AsRegistryOpts() registry.Opts {
 		Password: r.Password,
 		Token:    r.Token,
 		Anon:     r.Anon,
+
+		ResponseHeaderTimeout: r.ResponseHeaderTimeout,
 	}
 
 	if len(opts.Username) == 0 {

--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -29,6 +29,8 @@ type Opts struct {
 	Password string
 	Token    string
 	Anon     bool
+
+	ResponseHeaderTimeout time.Duration
 }
 
 type Registry struct {
@@ -223,7 +225,7 @@ func newHTTPTransport(opts Opts) (*http.Transport, error) {
 
 	clonedDefaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 	clonedDefaultTransport.ForceAttemptHTTP2 = false
-	clonedDefaultTransport.ResponseHeaderTimeout = 10 * time.Second
+	clonedDefaultTransport.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
 	clonedDefaultTransport.TLSClientConfig = &tls.Config{
 		RootCAs:            pool,
 		InsecureSkipVerify: opts.VerifyCerts == false,

--- a/test/helpers/fake_registry.go
+++ b/test/helpers/fake_registry.go
@@ -441,6 +441,15 @@ func (r *FakeTestRegistryBuilder) ResetHandler() *FakeTestRegistryBuilder {
 	return r
 }
 
+func (r *FakeTestRegistryBuilder) WithCustomHandler(handler http.HandlerFunc) {
+	parentHandler := r.server.Config.Handler
+
+	r.server.Config.Handler = http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		handler(writer, request)
+		parentHandler.ServeHTTP(writer, request)
+	})
+}
+
 type BundleInfo struct {
 	r          *FakeTestRegistryBuilder
 	Image      v1.Image


### PR DESCRIPTION
- increased the default timeout from 10s -> 30s
- refactor: Remove copied golang http.DefaultTransport
- It is easier to see what has been 'changed' from the DefaultTransport.

Authored-by: Dennis Leon <leonde@vmware.com>