### PR TITLE
bug fix: ensure correct bundle is referenced when generating lock file

### DIFF
--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -168,6 +168,19 @@ func (c *CopyOptions) writeLockOutput(bundleProcessedImage *ctlimgset.ProcessedI
 		if !ok {
 			panic(fmt.Errorf("Internal inconsistency: '%s' should be a bundle but it is not", bundleProcessedImage.DigestRef))
 		}
+	} else {
+		for _, item := range processedImages.All() {
+			plainImg := plainimage.NewFetchedPlainImageWithTag(item.DigestRef, item.UnprocessedImageRef.Tag, item.Image, item.ImageIndex)
+			bundle := bundle.NewBundleFromPlainImage(plainImg, registry)
+
+			ok, err := bundle.IsBundle()
+			if err != nil {
+				return fmt.Errorf("Check if '%s' is bundle: %s", item.DigestRef, err)
+			}
+			if ok {
+				return fmt.Errorf("Unable to determine correct root bundle to use for lock-output. hint: if copying from a tarball, try re-generating the tarball")
+			}
+		}
 	}
 
 	if c.LockOutputFlags.LockFilePath != "" {

--- a/pkg/imgpkg/cmd/copy_repo_src_test.go
+++ b/pkg/imgpkg/cmd/copy_repo_src_test.go
@@ -878,7 +878,7 @@ func assertTarballContainsOnlyDistributableLayers(imageTarPath string, t *testin
 
 func assertTarballLabelsOuterBundle(imageTarPath string, outerBundleRef string, t *testing.T) {
 	tarReader := imagetar.NewTarReader(imageTarPath)
-	imageReferencesFound, err := tarReader.FindByLabelKey("root.bundle")
+	imageReferencesFound, err := tarReader.FindByLabelKey("dev.carvel.imgpkg.copy.root-bundle")
 	assert.NoError(t, err)
 
 	assert.NotNil(t, imageReferencesFound)

--- a/pkg/imgpkg/imagedesc/image_ref_descriptors.go
+++ b/pkg/imgpkg/imagedesc/image_ref_descriptors.go
@@ -293,6 +293,26 @@ func (ids *ImageRefDescriptors) buildRef(otherRef regname.Reference, digest stri
 	return newRef
 }
 
+func (ids *ImageRefDescriptors) SetLabel(label map[string]interface{}, bundleRefToUpdate string) error {
+	foundBundleToUpdate := false
+	for i, desc := range ids.descs {
+		if desc.Image != nil {
+			for _, ref := range desc.Image.Refs {
+				if ref == bundleRefToUpdate {
+					ids.descs[i].Image.Labels = label
+					foundBundleToUpdate = true
+				}
+			}
+		}
+	}
+
+	if !foundBundleToUpdate {
+		return fmt.Errorf("unable to find %s to update label", bundleRefToUpdate)
+	}
+
+	return nil
+}
+
 type errRegistry struct {
 	delegate Registry
 }

--- a/pkg/imgpkg/imagedesc/types.go
+++ b/pkg/imgpkg/imagedesc/types.go
@@ -64,7 +64,11 @@ type ImageDescriptor struct {
 	Config   ConfigDescriptor
 	Manifest ManifestDescriptor
 	Tag      string
+
+	Labels map[string]interface{}
 }
+
+//TODO: test backwards compat. i.e. new imgpkg creates tar, read by an old imgpkg
 
 type ImageLayerDescriptor struct {
 	MediaType string

--- a/pkg/imgpkg/imagedesc/types.go
+++ b/pkg/imgpkg/imagedesc/types.go
@@ -68,8 +68,6 @@ type ImageDescriptor struct {
 	Labels map[string]interface{}
 }
 
-//TODO: test backwards compat. i.e. new imgpkg creates tar, read by an old imgpkg
-
 type ImageLayerDescriptor struct {
 	MediaType string
 	Digest    string

--- a/pkg/imgpkg/imageset/tar_image_set.go
+++ b/pkg/imgpkg/imageset/tar_image_set.go
@@ -13,7 +13,7 @@ import (
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagetar"
 )
 
-const rootBundleLabelKey string = "root.bundle"
+const rootBundleLabelKey string = "dev.carvel.imgpkg.copy.root-bundle"
 
 type TarImageSet struct {
 	imageSet    ImageSet

--- a/pkg/imgpkg/imagetar/tar_reader.go
+++ b/pkg/imgpkg/imagetar/tar_reader.go
@@ -17,32 +17,51 @@ func NewTarReader(path string) TarReader {
 	return TarReader{path}
 }
 
-func (r TarReader) Read() (*imagedesc.ImageDescriptor, []imagedesc.ImageOrIndex, error) {
+func (r TarReader) FindByLabelKey(key string) ([]*imagedesc.ImageDescriptor, error) {
+	var foundImageDescriptors []*imagedesc.ImageDescriptor
+
 	file := tarFile{r.path}
 
+	ids, err := r.getIdsFromManifest(file)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, descriptor := range ids.Descriptors() {
+		if descriptor.Image != nil {
+			if _, found := descriptor.Image.Labels[key]; found {
+				foundImageDescriptors = append(foundImageDescriptors, descriptor.Image)
+			}
+		}
+	}
+	return foundImageDescriptors, nil
+}
+
+func (r TarReader) Read() ([]imagedesc.ImageOrIndex, error) {
+	file := tarFile{r.path}
+
+	ids, err := r.getIdsFromManifest(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return imagedesc.NewDescribedReader(ids, file).Read(), nil
+}
+
+func (r TarReader) getIdsFromManifest(file tarFile) (*imagedesc.ImageRefDescriptors, error) {
 	manifestFile, err := file.Chunk("manifest.json").Open()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	manifestBytes, err := ioutil.ReadAll(manifestFile)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	ids, err := imagedesc.NewImageRefDescriptorsFromBytes(manifestBytes)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	var mainBundle *imagedesc.ImageDescriptor
-	for _, descriptor := range ids.Descriptors() {
-		if descriptor.Image != nil {
-			if _, found := descriptor.Image.Labels["main.bundle"]; found {
-				mainBundle = descriptor.Image
-			}
-		}
-	}
-
-	return mainBundle, imagedesc.NewDescribedReader(ids, file).Read(), nil
+	return ids, nil
 }

--- a/test/helpers/assertion.go
+++ b/test/helpers/assertion.go
@@ -28,7 +28,7 @@ type Assertion struct {
 
 func (a *Assertion) ImagesDigestIsOnTar(tarFilePath string, imagesDigestRef ...string) {
 	a.T.Helper()
-	imagesOrIndexes, err := imagetar.NewTarReader(tarFilePath).Read()
+	_, imagesOrIndexes, err := imagetar.NewTarReader(tarFilePath).Read()
 	require.NoError(a.T, err)
 
 	for _, imageOrIndex := range imagesOrIndexes {

--- a/test/helpers/assertion.go
+++ b/test/helpers/assertion.go
@@ -28,7 +28,7 @@ type Assertion struct {
 
 func (a *Assertion) ImagesDigestIsOnTar(tarFilePath string, imagesDigestRef ...string) {
 	a.T.Helper()
-	_, imagesOrIndexes, err := imagetar.NewTarReader(tarFilePath).Read()
+	imagesOrIndexes, err := imagetar.NewTarReader(tarFilePath).Read()
 	require.NoError(a.T, err)
 
 	for _, imageOrIndex := range imagesOrIndexes {


### PR DESCRIPTION
Attempts to fix: https://github.com/vmware-tanzu/carvel-imgpkg/issues/159

Authored-by: Dennis Leon <leonde@vmware.com>