### PR TITLE
improve --help short description

### DIFF
--- a/pkg/imgpkg/cmd/imgpkg.go
+++ b/pkg/imgpkg/cmd/imgpkg.go
@@ -28,7 +28,7 @@ func NewDefaultImgpkgCmd(ui *ui.ConfUI) *cobra.Command {
 func NewImgpkgCmd(o *ImgpkgOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "imgpkg",
-		Short:             "imgpkg stores files as Docker images",
+		Short:             "imgpkg creates an immutable OCI artifact suitable for containing configuration and images used in that configuration",
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
Removes references to "Docker images".

This PR attempts to make the 'front page' of the help command a bit more useful.

Authored-by: Dennis Leon <leonde@vmware.com>