### PR TITLE
Attempt to prevent location-oci from mutating un-intentionally

### DIFF
--- a/pkg/imgpkg/bundle/bundle.go
+++ b/pkg/imgpkg/bundle/bundle.go
@@ -117,11 +117,17 @@ func (o *Bundle) NoteCopy(processedImages *imageset.ProcessedImages, reg ImagesM
 
 	logger.Debugf("creating Locations OCI Image\n")
 	// Using NewNoopUI because we do not want to have output from this push
-	err = NewLocations(logger).Save(reg, destinationRef, locationsCfg, goui.NewNoopUI())
-	if err != nil {
-		return err
+
+	locations := NewLocations(logger)
+	_, err = locations.Fetch(reg, destinationRef)
+	if _, ok := err.(*LocationsNotFound); ok {
+		err = locations.Save(reg, destinationRef, locationsCfg, goui.NewNoopUI())
+		if err != nil {
+			return err
+		}
 	}
-	return nil
+
+	return err
 }
 
 func (o *Bundle) Pull(outputPath string, ui goui.UI, pullNestedBundles bool) error {


### PR DESCRIPTION
Attempts to address https://github.com/vmware-tanzu/carvel-imgpkg/issues/199

I was unable to pin-point where / how a location-oci might mutate across runs.

This PR is a 'defensive' measure to try and prevent mutations from occurring in the future. Really to prevent issues for folk who are using a registry with immutable tags.

- does not handle concurrency race conditions i.e. more than 1 imgpkg copy from
running at the same time might still mutate an oci-location image.
- introduces a slight perf penalty. although the location-oci should be
'small' in size

Authored-by: Dennis Leon <leonde@vmware.com>