### PR TITLE
add --image-is-bundle-check=bool flag to allow fetching bundles as plain images via imgpkg pull

### DIFF
--- a/pkg/imgpkg/cmd/pull.go
+++ b/pkg/imgpkg/cmd/pull.go
@@ -18,6 +18,7 @@ type PullOptions struct {
 	ui ui.UI
 
 	ImageFlags           ImageFlags
+	ImageIsBundleCheck   bool
 	RegistryFlags        RegistryFlags
 	BundleFlags          BundleFlags
 	LockInputFlags       LockInputFlags
@@ -42,6 +43,7 @@ func NewPullCmd(o *PullOptions) *cobra.Command {
   imgpkg pull -i repo/app1-image -o /tmp/app1-image`,
 	}
 	o.ImageFlags.Set(cmd)
+	cmd.Flags().BoolVar(&o.ImageIsBundleCheck, "image-is-bundle-check", true, "Error when image is a bundle (disable pulling bundles via -i)")
 	o.RegistryFlags.Set(cmd)
 	o.BundleFlags.Set(cmd)
 	o.BundleRecursiveFlags.Set(cmd)
@@ -86,22 +88,25 @@ func (po *PullOptions) Run() error {
 
 	case len(po.ImageFlags.Image) > 0:
 		plainImg := plainimage.NewPlainImage(po.ImageFlags.Image, reg)
+
 		isImage, err := plainImg.IsImage()
 		if err != nil {
 			return err
 		}
-
 		if !isImage {
 			return fmt.Errorf("Unable to pull non-images, such as image indexes. (hint: provide a specific digest to the image instead)")
 		}
 
-		ok, err := bundle.NewBundleFromPlainImage(plainImg, reg).IsBundle()
-		if err != nil {
-			return err
+		if po.ImageIsBundleCheck {
+			isBundle, err := bundle.NewBundleFromPlainImage(plainImg, reg).IsBundle()
+			if err != nil {
+				return err
+			}
+			if isBundle {
+				return fmt.Errorf("Expected bundle flag when pulling a bundle (hint: Use -b instead of -i for bundles)")
+			}
 		}
-		if ok {
-			return fmt.Errorf("Expected bundle flag when pulling a bundle (hint: Use -b instead of -i for bundles)")
-		}
+
 		return plainImg.Pull(po.OutputPath, po.ui)
 
 	default:


### PR DESCRIPTION
fixes https://github.com/vmware-tanzu/carvel-imgpkg/issues/206

works:

```
imgpkg pull -i k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c -o /tmp/lol --image-is-bundle-check=false
```