### PR TITLE
Test with gcr registry

### DIFF
--- a/.github/workflows/gh-test-external-registry.yml
+++ b/.github/workflows/gh-test-external-registry.yml
@@ -91,11 +91,20 @@ jobs:
           # pull registry for e2e tests that require a locally running docker registry. i.e. airgapped env tests
           docker pull registry:2
 
+          function cleanup {
+            set +e
+            {
+              gcloud auth activate-service-account --key-file <(echo "$GCR_PASSWORD")
+              gcloud config set project cf-k8s-lifecycle-tooling-klt > /dev/null
+              gcloud container images list --filter=$GITHUB_RUN_ID | while read img; do
+                gcloud container images list-tags $img --format='get(digest)' | while read img_sha_to_delete; do
+                  gcloud container images delete "${img}@${img_sha_to_delete}" --force-delete-tags --quiet
+                done
+              done
+            } > /dev/null
+          }
+
+          trap cleanup EXIT
+
           ./hack/test-all.sh
 
-          gcloud auth activate-service-account --key-file <(echo "$GCR_PASSWORD")
-          gcloud container images list --filter=$GITHUB_RUN_ID | while read img; do
-            gcloud container images list-tags $img --format='get(digest)' | while read img_sha_to_delete; do
-              gcloud container images delete "${img}@${img_sha_to_delete}" --force-delete-tags --quiet
-            done
-          done

--- a/.github/workflows/gh-test-external-registry.yml
+++ b/.github/workflows/gh-test-external-registry.yml
@@ -55,3 +55,47 @@ jobs:
         docker pull registry:2
 
         ./hack/test-all.sh
+  test-gcr:
+    name: Test GH with GCR
+    runs-on: ubuntu-latest
+    environment: GCR e2e
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.16"
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: src/github.com/${{ github.repository }}
+          persist-credentials: false
+      - name: Run Tests
+        env:
+          IMGPKG_E2E_IMAGE: "gcr.io/cf-k8s-lifecycle-tooling-klt/github-action-test-relocation"
+          IMGPKG_E2E_RELOCATION_REPO: "gcr.io/cf-k8s-lifecycle-tooling-klt/github-action-imgpkg-test"
+          GCR_PASSWORD: ${{ secrets.GCR_PASSWORD }}
+        run: |
+          set -e
+
+          # Prevent conflicts from multiple e2e tests run in parallel from diff PR's
+          export IMGPKG_E2E_IMAGE="$IMGPKG_E2E_IMAGE-$GITHUB_RUN_ID"
+          export IMGPKG_E2E_RELOCATION_REPO="$IMGPKG_E2E_RELOCATION_REPO-$GITHUB_RUN_ID"
+
+          export GOPATH=$(echo `pwd`)
+          export PATH="$PATH:$GOPATH/bin"
+          cd src/github.com/${{ github.repository }}
+
+          docker login -u _json_key --password-stdin https://gcr.io <<< "$GCR_PASSWORD"
+
+          # pull registry for e2e tests that require a locally running docker registry. i.e. airgapped env tests
+          docker pull registry:2
+
+          ./hack/test-all.sh
+
+          gcloud auth activate-service-account --key-file <(echo "$GCR_PASSWORD")
+          gcloud container images list --filter=$GITHUB_RUN_ID | while read img; do
+            gcloud container images list-tags $img --format='get(digest)' | while read img_sha_to_delete; do
+              gcloud container images delete "${img}@${img_sha_to_delete}" --force-delete-tags --quiet
+            done
+          done

--- a/test/helpers/image_factory.go
+++ b/test/helpers/image_factory.go
@@ -43,11 +43,11 @@ func (i *ImageFactory) ImageDigest(imgRef string) string {
 	return digest.String()
 }
 
-func (i *ImageFactory) PushImageWithANonDistributableLayer(imgRef string) string {
+func (i *ImageFactory) PushImageWithANonDistributableLayer(imgRef string, mediaType types.MediaType) string {
 	imageRef, err := name.ParseReference(imgRef, name.WeakValidation)
 	require.NoError(i.T, err)
 
-	layer, err := random.Layer(1024, types.OCIUncompressedRestrictedLayer)
+	layer, err := random.Layer(1024, mediaType)
 	require.NoError(i.T, err)
 	digest, err := layer.Digest()
 	require.NoError(i.T, err)


### PR DESCRIPTION
Addresses #138

Add GH Action to run tests against GCR
 
- After tests are run, the images created by the tests are deleted.
-- IAM was configured by following: https://cloud.google.com/container-registry/docs/access-control

See test run here:
https://github.com/vmware-tanzu/carvel-imgpkg/runs/3364818396

*** Prior to Merging ***
~~The "GCR e2e" environment needs to be created and configured with a secret `GCR_PASSWORD`~~