### PR TITLE
Fix typo: `constains` -> `contains`

### DIFF
--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -113,7 +113,7 @@ func (b Contents) validateImgpkgDirs(imgpkgDirs []string) error {
 
 		msg := fmt.Sprintf("This directory is not a bundle. It it is missing %s", imgpkgPath)
 		if len(imgpkgDirs) > 0 {
-			msg = fmt.Sprintf("This directory constains multiple bundle definitions. Only a single instance of %s can be provided and instead these were provided %s", imgpkgPath, strings.Join(imgpkgDirs, ", "))
+			msg = fmt.Sprintf("This directory contains multiple bundle definitions. Only a single instance of %s can be provided and instead these were provided %s", imgpkgPath, strings.Join(imgpkgDirs, ", "))
 		}
 
 		return bundleValidationError{msg}

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -111,7 +111,7 @@ func (b Contents) validateImgpkgDirs(imgpkgDirs []string) error {
 	if len(imgpkgDirs) != 1 {
 		imgpkgPath := filepath.Join(ImgpkgDir, ImagesLockFile)
 
-		msg := fmt.Sprintf("This directory is not a bundle. It it is missing %s", imgpkgPath)
+		msg := fmt.Sprintf("This directory is not a bundle. It is missing %s", imgpkgPath)
 		if len(imgpkgDirs) > 0 {
 			msg = fmt.Sprintf("This directory contains multiple bundle definitions. Only a single instance of %s can be provided and instead these were provided %s", imgpkgPath, strings.Join(imgpkgDirs, ", "))
 		}

--- a/pkg/imgpkg/cmd/push_test.go
+++ b/pkg/imgpkg/cmd/push_test.go
@@ -133,7 +133,7 @@ func TestBundleDirectoryErrors(t *testing.T) {
 		{
 			name:            "no bundle",
 			createBundleDir: false,
-			expectedError:   "This directory is not a bundle. It it is missing .imgpkg/images.yml",
+			expectedError:   "This directory is not a bundle. It is missing .imgpkg/images.yml",
 		},
 	}
 

--- a/pkg/imgpkg/cmd/push_test.go
+++ b/pkg/imgpkg/cmd/push_test.go
@@ -56,7 +56,7 @@ func TestMultiImgpkgDirError(t *testing.T) {
 		t.Fatalf("Expected validations to err, but did not")
 	}
 
-	if !strings.Contains(err.Error(), "This directory constains multiple bundle definitions. Only a single instance of .imgpkg/images.yml can be provided") {
+	if !strings.Contains(err.Error(), "This directory contains multiple bundle definitions. Only a single instance of .imgpkg/images.yml can be provided") {
 		t.Fatalf("Expected error to contain message about multiple .imgpkg dirs, got: %s", err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>