### PR TITLE
Improve debugging failures 130

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 /test/e2e/assets/simple-app/empty-dir
 dist/
+.idea

--- a/pkg/imgpkg/cmd/debug_flags.go
+++ b/pkg/imgpkg/cmd/debug_flags.go
@@ -1,0 +1,27 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// DebugFlags indicates debugging
+type DebugFlags struct {
+	Debug bool
+}
+
+// Set adds the debug flag to the command
+func (f *DebugFlags) Set(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(&f.Debug, "debug", false, "Enables debugging")
+}
+
+// ConfigureDebug set debug output to os.Stdout
+func (f *DebugFlags) ConfigureDebug() {
+	if f.Debug {
+		logs.Debug.SetOutput(os.Stderr)
+	}
+}

--- a/pkg/imgpkg/cmd/imgpkg.go
+++ b/pkg/imgpkg/cmd/imgpkg.go
@@ -14,7 +14,8 @@ import (
 type ImgpkgOptions struct {
 	ui *ui.ConfUI
 
-	UIFlags UIFlags
+	UIFlags    UIFlags
+	DebugFlags DebugFlags
 }
 
 func NewImgpkgOptions(ui *ui.ConfUI) *ImgpkgOptions {
@@ -42,6 +43,7 @@ func NewImgpkgCmd(o *ImgpkgOptions) *cobra.Command {
 	cmd.SetErr(blockWriter)
 
 	o.UIFlags.Set(cmd)
+	o.DebugFlags.Set(cmd)
 
 	cmd.AddCommand(NewPushCmd(NewPushOptions(o.ui)))
 	cmd.AddCommand(NewPullCmd(NewPullOptions(o.ui)))
@@ -59,6 +61,7 @@ func NewImgpkgCmd(o *ImgpkgOptions) *cobra.Command {
 
 	cobrautil.VisitCommands(cmd, cobrautil.WrapRunEForCmd(func(*cobra.Command, []string) error {
 		o.UIFlags.ConfigureUI(o.ui)
+		o.DebugFlags.ConfigureDebug()
 		return nil
 	}))
 

--- a/test/e2e/debug_test.go
+++ b/test/e2e/debug_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/k14s/imgpkg/test/helpers"
+)
+
+func TestDebugDisabled(t *testing.T) {
+	env := helpers.BuildEnv(t)
+	imgpkg := helpers.Imgpkg{T: t, L: helpers.Logger{}, ImgpkgPath: env.ImgpkgPath}
+	defer env.Cleanup()
+
+	registry := helpers.NewFakeRegistry(t, &helpers.Logger{})
+	registry.Build()
+	defer registry.ResetHandler()
+
+	repo := registry.ReferenceOnTestServer("nothing")
+	out := bytes.NewBufferString("")
+	_, err := imgpkg.RunWithOpts([]string{"pull", "--tty", "-i", repo, "-o", "/dev/null"}, helpers.RunOpts{
+		AllowError:   true,
+		StderrWriter: out,
+		StdoutWriter: out,
+	})
+
+	assert.Error(t, err)
+	assert.Regexp(t, `^imgpkg: Error: Fetching image:
+\s+GET http://127.0.0.1:[0-9]+/v2/nothing/manifests/latest:
+\s+NAME_UNKNOWN:
+\s+Unknown name`, out.String())
+}
+
+func TestDebugEnabled(t *testing.T) {
+	env := helpers.BuildEnv(t)
+	imgpkg := helpers.Imgpkg{T: t, L: helpers.Logger{}, ImgpkgPath: env.ImgpkgPath}
+	defer env.Cleanup()
+
+	registry := helpers.NewFakeRegistry(t, &helpers.Logger{})
+	registry.Build()
+	defer registry.ResetHandler()
+
+	repo := registry.ReferenceOnTestServer("nothing")
+	out := bytes.NewBufferString("")
+	_, err := imgpkg.RunWithOpts([]string{"pull", "--tty", "-i", repo, "--debug", "-o", "/dev/null"}, helpers.RunOpts{
+		AllowError:   true,
+		StderrWriter: out,
+		StdoutWriter: out,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, out.String(), "Accept-Encoding")
+}


### PR DESCRIPTION
Add `--debug` flag to enable logging of ggcr debug information.