### PR TITLE
Make HOSTNAME matching more permissive

### DIFF
--- a/pkg/imgpkg/registry/auth/env_keychain.go
+++ b/pkg/imgpkg/registry/auth/env_keychain.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	regauthn "github.com/google/go-containerregistry/pkg/authn"
+	credentialprovider "github.com/vdemeester/k8s-pkg-credentialprovider"
 )
 
 var _ regauthn.Keychain = &EnvKeychain{}
@@ -40,7 +41,7 @@ func (k *EnvKeychain) Resolve(target regauthn.Resource) (regauthn.Authenticator,
 	}
 
 	for _, info := range infos {
-		if info.Hostname == target.RegistryStr() {
+		if match, _ := credentialprovider.URLsMatchStr(info.Hostname, target.RegistryStr()); match {
 			return regauthn.FromConfig(regauthn.AuthConfig{
 				Username:      info.Username,
 				Password:      info.Password,

--- a/pkg/imgpkg/registry/keychain_test.go
+++ b/pkg/imgpkg/registry/keychain_test.go
@@ -246,8 +246,10 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 		"https://localhost:9999",
 		"localhost:9999/v1/",
 		"localhost:9999/v2/",
+		"*:9999/v2/",
+		"local*:9999/v2/",
 	} {
-		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", validHostname, i), func(t *testing.T) {
 			envVars := []string{
 				"IMGPKG_REGISTRY_USERNAME=user",
 				"IMGPKG_REGISTRY_PASSWORD=pass",
@@ -275,7 +277,7 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 		"http://[%10::1]",        // no %xx escapes in IP address
 		"http://%41:8080/",       // not allowed: % encoding only for non-ASCII
 	} {
-		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", invalidHostname, i), func(t *testing.T) {
 			envVars := []string{
 				"IMGPKG_REGISTRY_USERNAME=user",
 				"IMGPKG_REGISTRY_PASSWORD=pass",

--- a/pkg/imgpkg/registry/keychain_test.go
+++ b/pkg/imgpkg/registry/keychain_test.go
@@ -131,6 +131,8 @@ func TestAuthProvidedViaCLI(t *testing.T) {
 }
 
 func TestAuthProvidedViaEnvVars(t *testing.T) {
+	providedImage := "localhost:9999/imgpkg_test"
+
 	t.Run("When a single registry credentials is provided", func(t *testing.T) {
 		envVars := []string{
 			"IMGPKG_REGISTRY_USERNAME=user",
@@ -140,7 +142,7 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 
 		keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
 		require.NoError(t, err)
-		resource, err := name.NewRepository("localhost:9999/imgpkg_test")
+		resource, err := name.NewRepository(providedImage)
 		assert.NoError(t, err)
 
 		auth, err := keychain.Resolve(resource)
@@ -160,7 +162,7 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 
 		keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
 		require.NoError(t, err)
-		resource, err := name.NewRepository("localhost:9999/imgpkg_test")
+		resource, err := name.NewRepository(providedImage)
 		assert.NoError(t, err)
 
 		auth, err := keychain.Resolve(resource)
@@ -179,7 +181,7 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 
 		keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
 		require.NoError(t, err)
-		resource, err := name.NewRepository("localhost:9999/imgpkg_test")
+		resource, err := name.NewRepository(providedImage)
 		assert.NoError(t, err)
 
 		auth, err := keychain.Resolve(resource)
@@ -228,7 +230,7 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 
 		keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
 		require.NoError(t, err)
-		resource, err := name.NewRepository("localhost:9999/imgpkg_test")
+		resource, err := name.NewRepository(providedImage)
 		assert.NoError(t, err)
 
 		auth, err := keychain.Resolve(resource)
@@ -240,26 +242,34 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 		}), auth)
 	})
 
-	for i, validHostname := range []string{
-		"localhost:9999",
-		"http://localhost:9999",
-		"https://localhost:9999",
-		"localhost:9999/v1/",
-		"localhost:9999/v2/",
-		"*:9999/v2/",
-		"local*:9999/v2/",
-	} {
-		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", validHostname, i), func(t *testing.T) {
+	testCasesWithMatchingHostnames := []struct {
+		targetImage      string
+		providedHostname string
+	}{
+		{providedImage, "localhost:9999"},
+		{providedImage, "http://localhost:9999"},
+		{providedImage, "https://localhost:9999"},
+		{providedImage, "localhost:9999/v1/"},
+		{providedImage, "localhost:9999/v2/"},
+		{providedImage, "*:9999/v2/"},
+		{providedImage, "local*:9999/v2/"},
+		{"subdomain.localhost:9999/imgpkg_test", "*.localhost:9999/v2/"},
+		{"subdomain1.subdomain2.localhost:9999/imgpkg_test", "*.*.localhost:9999/v2/"},
+		{providedImage, providedImage},
+	}
+
+	for i, tc := range testCasesWithMatchingHostnames {
+		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", tc.providedHostname, i), func(t *testing.T) {
 			envVars := []string{
 				"IMGPKG_REGISTRY_USERNAME=user",
 				"IMGPKG_REGISTRY_PASSWORD=pass",
-				fmt.Sprintf("IMGPKG_REGISTRY_HOSTNAME=%s", validHostname),
+				fmt.Sprintf("IMGPKG_REGISTRY_HOSTNAME=%s", tc.providedHostname),
 			}
 
 			keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
 			assert.NoError(t, err)
 
-			resource, err := name.NewRepository("localhost:9999/imgpkg_test")
+			resource, err := name.NewRepository(tc.targetImage)
 			assert.NoError(t, err)
 
 			auth, err := keychain.Resolve(resource)
@@ -272,26 +282,125 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 		})
 	}
 
-	for i, invalidHostname := range []string{
-		"http://[::1]:namedport", // rfc3986 3.2.3
-		"http://[%10::1]",        // no %xx escapes in IP address
-		"http://%41:8080/",       // not allowed: % encoding only for non-ASCII
-	} {
-		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", invalidHostname, i), func(t *testing.T) {
+	testCasesWithNonMatchingHostnames := []struct {
+		targetImage      string
+		providedHostname string
+	}{
+		{"subdomain1.subdomain2.localhost:9999/imgpkg_test", "*.localhost:9999"},
+		{"subdomain1.localhost:9999/imgpkg_test", "localhost:9999"},
+		{"subdomain1.localhost:9999/imgpkg_test", "*:9999"},
+	}
+
+	for i, tc := range testCasesWithNonMatchingHostnames {
+		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", tc.providedHostname, i), func(t *testing.T) {
 			envVars := []string{
 				"IMGPKG_REGISTRY_USERNAME=user",
 				"IMGPKG_REGISTRY_PASSWORD=pass",
-				fmt.Sprintf("IMGPKG_REGISTRY_HOSTNAME=%s", invalidHostname),
+				fmt.Sprintf("IMGPKG_REGISTRY_HOSTNAME=%s", tc.providedHostname),
 			}
 
 			keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
 			assert.NoError(t, err)
 
-			resource, err := name.NewRepository("localhost:9999/imgpkg_test")
+			resource, err := name.NewRepository(tc.targetImage)
+			assert.NoError(t, err)
+
+			auth, err := keychain.Resolve(resource)
+			assert.NoError(t, err)
+
+			assert.Equal(t, authn.Anonymous, auth)
+		})
+	}
+
+	for i, testCasesWithInvalidHostname := range []string{
+		"http://[::1]:namedport", // rfc3986 3.2.3
+		"http://[%10::1]",        // no %xx escapes in IP address
+		"http://%41:8080/",       // not allowed: % encoding only for non-ASCII
+	} {
+		t.Run(fmt.Sprintf("IMGPKG_HOSTNAME %s/%d", testCasesWithInvalidHostname, i), func(t *testing.T) {
+			envVars := []string{
+				"IMGPKG_REGISTRY_USERNAME=user",
+				"IMGPKG_REGISTRY_PASSWORD=pass",
+				fmt.Sprintf("IMGPKG_REGISTRY_HOSTNAME=%s", testCasesWithInvalidHostname),
+			}
+
+			keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
+			assert.NoError(t, err)
+
+			resource, err := name.NewRepository(providedImage)
 			assert.NoError(t, err)
 
 			_, err = keychain.Resolve(resource)
 			assert.Error(t, err)
+		})
+	}
+
+	testCasesSpecifyingOrder := []struct {
+		envs             []string
+		expectedUsername string
+		expectedPassword string
+	}{
+		{
+			[]string{
+				"IMGPKG_REGISTRY_USERNAME_0=user-not-chosen",
+				"IMGPKG_REGISTRY_PASSWORD_0=pass-not-chosen",
+				"IMGPKG_REGISTRY_HOSTNAME_0=localhost:9999",
+				"IMGPKG_REGISTRY_USERNAME_1=user",
+				"IMGPKG_REGISTRY_PASSWORD_1=pass",
+				"IMGPKG_REGISTRY_HOSTNAME_1=localhost:9999/imgpkg_test",
+			},
+			"user", "pass",
+		},
+		{
+			[]string{
+				"IMGPKG_REGISTRY_USERNAME_0=user-not-chosen",
+				"IMGPKG_REGISTRY_PASSWORD_0=pass-not-chosen",
+				"IMGPKG_REGISTRY_HOSTNAME_0=localhost:9999/imgpkg_test",
+				"IMGPKG_REGISTRY_USERNAME_1=user",
+				"IMGPKG_REGISTRY_PASSWORD_1=pass",
+				"IMGPKG_REGISTRY_HOSTNAME_1=localhost:9999/imgpkg_test/imagename",
+			},
+			"user", "pass",
+		},
+		{
+			[]string{
+				"IMGPKG_REGISTRY_USERNAME_0=user-not-chosen",
+				"IMGPKG_REGISTRY_PASSWORD_0=pass-not-chosen",
+				"IMGPKG_REGISTRY_HOSTNAME_0=*:9999/imgpkg_test/imagename",
+				"IMGPKG_REGISTRY_USERNAME_1=user",
+				"IMGPKG_REGISTRY_PASSWORD_1=pass",
+				"IMGPKG_REGISTRY_HOSTNAME_1=localhost:9999",
+			},
+			"user", "pass",
+		},
+		{
+			[]string{
+				"IMGPKG_REGISTRY_USERNAME_0=user-not-chosen",
+				"IMGPKG_REGISTRY_PASSWORD_0=pass-not-chosen",
+				"IMGPKG_REGISTRY_HOSTNAME_0=localhost:9999/v1/",
+				"IMGPKG_REGISTRY_USERNAME_1=user",
+				"IMGPKG_REGISTRY_PASSWORD_1=pass",
+				"IMGPKG_REGISTRY_HOSTNAME_1=localhost:9999/imgpkg_test",
+			},
+			"user", "pass",
+		},
+	}
+
+	for i, tc := range testCasesSpecifyingOrder {
+		t.Run(fmt.Sprintf("ensure more specific HOSTNAME is used: %d", i), func(t *testing.T) {
+			keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return tc.envs })
+			assert.NoError(t, err)
+
+			resource, err := name.NewRepository("localhost:9999/imgpkg_test/imagename")
+			assert.NoError(t, err)
+
+			auth, err := keychain.Resolve(resource)
+			assert.NoError(t, err)
+
+			assert.Equal(t, authn.FromConfig(authn.AuthConfig{
+				Username: tc.expectedUsername,
+				Password: tc.expectedPassword,
+			}), auth)
 		})
 	}
 }


### PR DESCRIPTION
Related to: 
https://github.com/vmware-tanzu/carvel-imgpkg/issues/234
https://github.com/vmware-tanzu/carvel-imgpkg/issues/235

`IMGPKG_REGISTRY_HOSTNAME` matching now allows:
- schemes (http/https)
- v1 and v2 in the path to be the equivalent to just passing the hostname
- glob patterns in the HOSTNAME (currently wildcards are not supported in ports and paths)

# Before merging

to avoid merge difficulty, this PR should be merged after https://github.com/vmware-tanzu/carvel-imgpkg/pull/220



TODO:

- [ ] Update docs to reflect new behavior of `IMGPKG_REGISTRY_HOSTNAME`