### PR TITLE
Allow setting azure-config-file via env variable

### DIFF
--- a/pkg/imgpkg/registry/auth/env_keychain.go
+++ b/pkg/imgpkg/registry/auth/env_keychain.go
@@ -145,7 +145,7 @@ func (k *EnvKeychain) collect() ([]envKeychainInfo, error) {
 			continue
 		}
 
-		if !strings.HasPrefix(pieces[0], globalEnvironPrefix) {
+		if !strings.HasPrefix(pieces[0], globalEnvironPrefix) || pieces[0] == "IMGPKG_REGISTRY_AZURE_CR_CONFIG" {
 			continue
 		}
 

--- a/pkg/imgpkg/registry/keychain_test.go
+++ b/pkg/imgpkg/registry/keychain_test.go
@@ -242,6 +242,20 @@ func TestAuthProvidedViaEnvVars(t *testing.T) {
 		}), auth)
 	})
 
+	t.Run("Do not error if AZURE_CR_CONFIG env var is set", func(t *testing.T) {
+		envVars := []string{
+			"IMGPKG_REGISTRY_AZURE_CR_CONFIG=/some/path",
+		}
+
+		keychain, err := registry.Keychain(auth.KeychainOpts{}, func() []string { return envVars })
+		require.NoError(t, err)
+		resource, err := name.NewRepository(providedImage)
+		assert.NoError(t, err)
+
+		_, err = keychain.Resolve(resource)
+		assert.NoError(t, err)
+	})
+
 	testCasesWithMatchingHostnames := []struct {
 		targetImage      string
 		providedHostname string


### PR DESCRIPTION
POC

- before running a command, replace the string pointer used in the azure provider, to whatever was provided to the imgpkg registry azure flag (or env var)

Authored-by: Dennis Leon <leonde@vmware.com>