### PR TITLE
Disable default docker config provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /imgpkg
 /imgpkg-darwin-amd64
-/imgpkg-darwin-arm66
+/imgpkg-darwin-arm64
 /imgpkg-linux-amd64
 /imgpkg-windows-amd64.exe
 /tmp

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -12,6 +12,12 @@ go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor
 go mod tidy
 
+# related to https://github.com/vmware-tanzu/carvel-imgpkg/pull/255
+# there doesn't appear to be a simple way to disable the defaultDockerConfigProvider
+# Having defaultDockerConfigProvider enabled by default results in the imgpkg auth ordering not working correctly
+# Specifically, the docker config.json is loaded before cli flags (and maybe even IaaS metadata services)
+git apply ./hack/patch-k8s-pkg-credentialprovider.patch
+
 # makes builds reproducible
 export CGO_ENABLED=0
 LDFLAGS="-X github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version=$VERSION -buildid="

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,6 +10,12 @@ go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor
 go mod tidy
 
+# related to https://github.com/vmware-tanzu/carvel-imgpkg/pull/255
+# there doesn't appear to be a simple way to disable the defaultDockerConfigProvider
+# Having defaultDockerConfigProvider enabled by default results in the imgpkg auth ordering not working correctly
+# Specifically, the docker config.json is loaded before cli flags (and maybe even IaaS metadata services)
+git apply ./hack/patch-k8s-pkg-credentialprovider.patch
+
 # export GOOS=linux GOARCH=amd64
 go build -ldflags="$LDFLAGS" -trimpath -o imgpkg ./cmd/imgpkg/...
 ./imgpkg version

--- a/hack/patch-k8s-pkg-credentialprovider.patch
+++ b/hack/patch-k8s-pkg-credentialprovider.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go b/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
+index 8c9ad34..f953bb4 100644
+--- a/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
++++ b/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
+@@ -70,7 +70,7 @@ type CachingDockerConfigProvider struct {
+ 
+ // Enabled implements dockerConfigProvider
+ func (d *defaultDockerConfigProvider) Enabled() bool {
+-	return true
++	return false
+ }
+ 
+ // Provide implements dockerConfigProvider

--- a/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
+++ b/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
@@ -70,7 +70,7 @@ type CachingDockerConfigProvider struct {
 
 // Enabled implements dockerConfigProvider
 func (d *defaultDockerConfigProvider) Enabled() bool {
-	return true
+	return false
 }
 
 // Provide implements dockerConfigProvider


### PR DESCRIPTION
TODO:

- [x] Add a bunch of comments and documentation around this hack-around
~- [ ] Submit an issue/PR upstream to allow disabling the default docker provider. Extend this change: https://github.com/kubernetes/kubernetes/commit/a947c32783e9027922762d6f76f5c27926f9bc0a#diff-0ebbc5bb19e182a89f5992c919d5fe2254af767f4611835010367b324b271df9R51-R53~