### PR TITLE
Standardize the logging mechanism in imgpkg

### DIFF
--- a/pkg/imgpkg/bundle/bundle_images_lock_test.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock_test.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"testing"
 
+	goui "github.com/cppforlife/go-cli-ui/ui"
 	regname "github.com/google/go-containerregistry/pkg/name"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle/bundlefakes"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
+	"github.com/k14s/imgpkg/pkg/imgpkg/util"
 	"github.com/k14s/imgpkg/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +43,10 @@ type imgAssertion struct {
 
 func TestBundle_AllImagesLock_NoLocations_AllImagesCollocated(t *testing.T) {
 	logger := &helpers.Logger{LogLevel: helpers.LogDebug}
+
+	confUI := goui.NewConfUI(goui.NewNoopLogger())
+	defer confUI.Flush()
+	uiLogger := util.NewUILevelLogger(util.LogWarn, confUI)
 
 	allTests := allImagesLockTests{
 		tests: []allImagesLockTest{
@@ -438,7 +444,7 @@ func TestBundle_AllImagesLock_NoLocations_AllImagesCollocated(t *testing.T) {
 			fmt.Println("============")
 
 			subject := bundle.NewBundleWithReader(topBundleInfo, registryFakeBuilder.Build(), fakeImagesLockReader)
-			bundles, imagesRefs, err := subject.AllImagesRefs(6, logger)
+			bundles, imagesRefs, err := subject.AllImagesRefs(6, uiLogger)
 			require.NoError(t, err)
 			runAssertions(t, test.assertions, imagesRefs, imagesTree)
 			checkBundlesPresence(t, bundles, imagesTree)
@@ -452,6 +458,10 @@ func TestBundle_AllImagesLock_NoLocations_AllImagesCollocated(t *testing.T) {
 
 func TestBundle_AllImagesLock_NoLocations_ImagesNotCollocated(t *testing.T) {
 	logger := &helpers.Logger{LogLevel: helpers.LogDebug}
+
+	confUI := goui.NewConfUI(goui.NewNoopLogger())
+	defer confUI.Flush()
+	uiLogger := util.NewUILevelLogger(util.LogWarn, confUI)
 
 	allTests := allImagesLockTests{
 		tests: []allImagesLockTest{
@@ -659,7 +669,7 @@ func TestBundle_AllImagesLock_NoLocations_ImagesNotCollocated(t *testing.T) {
 			fmt.Println("============")
 
 			subject := bundle.NewBundleWithReader(topBundleInfo, registryFakeBuilder.Build(), fakeImagesLockReader)
-			bundles, imagesRefs, err := subject.AllImagesRefs(1, logger)
+			bundles, imagesRefs, err := subject.AllImagesRefs(1, uiLogger)
 			require.NoError(t, err)
 			runAssertions(t, test.assertions, imagesRefs, imagesTree)
 			checkBundlesPresence(t, bundles, imagesTree)
@@ -673,6 +683,10 @@ func TestBundle_AllImagesLock_NoLocations_ImagesNotCollocated(t *testing.T) {
 
 func TestBundle_AllImagesLock_Locations_AllImagesCollocated(t *testing.T) {
 	logger := &helpers.Logger{LogLevel: helpers.LogDebug}
+
+	confUI := goui.NewConfUI(goui.NewNoopLogger())
+	defer confUI.Flush()
+	uiLogger := util.NewUILevelLogger(util.LogWarn, confUI)
 
 	allTests := allImagesLockTests{
 		tests: []allImagesLockTest{
@@ -1087,7 +1101,7 @@ func TestBundle_AllImagesLock_Locations_AllImagesCollocated(t *testing.T) {
 			fmt.Println("============")
 
 			subject := bundle.NewBundleWithReader(topBundleInfo, registryFakeBuilder.Build(), fakeImagesLockReader)
-			bundles, imagesRefs, err := subject.AllImagesRefs(6, logger)
+			bundles, imagesRefs, err := subject.AllImagesRefs(6, uiLogger)
 			require.NoError(t, err)
 			runAssertions(t, test.assertions, imagesRefs, imagesTree)
 			checkBundlesPresence(t, bundles, imagesTree)
@@ -1137,7 +1151,7 @@ func TestBundle_AllImagesLock_Locations_AllImagesCollocated(t *testing.T) {
 		fmt.Println("============")
 
 		subject := bundle.NewBundleWithReader(topBundleInfo, registryFakeBuilder.Build(), fakeImagesLockReader)
-		bundles, _, err := subject.AllImagesRefs(6, logger)
+		bundles, _, err := subject.AllImagesRefs(6, uiLogger)
 		require.NoError(t, err)
 		checkBundlesPresence(t, bundles, imagesTree)
 

--- a/pkg/imgpkg/bundle/bundle_test.go
+++ b/pkg/imgpkg/bundle/bundle_test.go
@@ -12,12 +12,14 @@ import (
 	"testing"
 
 	"github.com/cppforlife/go-cli-ui/ui"
+	goui "github.com/cppforlife/go-cli-ui/ui"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle/bundlefakes"
 	"github.com/k14s/imgpkg/pkg/imgpkg/imageset"
 	"github.com/k14s/imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/k14s/imgpkg/pkg/imgpkg/plainimage"
+	"github.com/k14s/imgpkg/pkg/imgpkg/util"
 	"github.com/k14s/imgpkg/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
@@ -819,9 +821,12 @@ func TestNoteCopy(t *testing.T) {
 		fakeRegistry.WithImmutableTags("repo/bundle-with-collocated-bundles", locationsImageTag)
 		defer fakeRegistry.ResetHandler()
 
-		logger := &helpers.Logger{LogLevel: helpers.LogDebug}
+		confUI := goui.NewConfUI(goui.NewNoopLogger())
+		defer confUI.Flush()
+		uiLogger := util.NewUILevelLogger(util.LogDebug, confUI)
+
 		subject := bundle.NewBundleFromPlainImage(plainimage.NewFetchedPlainImageWithTag(rootBundle.RefDigest, "", rootBundle.Image), reg)
-		_, _, err = subject.AllImagesRefs(1, logger)
+		_, _, err = subject.AllImagesRefs(1, uiLogger)
 		assert.NoError(t, err)
 
 		processedImages := imageset.NewProcessedImages()
@@ -840,7 +845,7 @@ func TestNoteCopy(t *testing.T) {
 			Image:     randomImageColocatedWithIcecreamBundle.Image,
 		})
 
-		err = subject.NoteCopy(processedImages, reg, logger)
+		err = subject.NoteCopy(processedImages, reg, uiLogger)
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/imgpkg/bundle/locations_configs.go
+++ b/pkg/imgpkg/bundle/locations_configs.go
@@ -42,23 +42,25 @@ func (n LocationsNotFound) Error() string {
 
 type LocationsConfigs struct {
 	reader LocationImageReader
-	logger util.LoggerWithLevels
+	ui     util.UIWithLevels
 }
 
 type LocationImageReader interface {
 	Read(img regv1.Image) (ImageLocationsConfig, error)
 }
 
-func NewLocations(logger util.LoggerWithLevels) *LocationsConfigs {
-	return NewLocationsWithReader(&locationsSingleLayerReader{}, logger)
+// NewLocations constructor for creating a LocationsConfigs
+func NewLocations(ui util.UIWithLevels) *LocationsConfigs {
+	return NewLocationsWithReader(&locationsSingleLayerReader{}, ui)
 }
 
-func NewLocationsWithReader(reader LocationImageReader, logger util.LoggerWithLevels) *LocationsConfigs {
-	return &LocationsConfigs{reader: reader, logger: logger}
+// NewLocationsWithReader constructor for LocationsConfigs
+func NewLocationsWithReader(reader LocationImageReader, ui util.UIWithLevels) *LocationsConfigs {
+	return &LocationsConfigs{reader: reader, ui: ui}
 }
 
 func (r LocationsConfigs) Fetch(registry ImagesMetadata, bundleRef name.Digest) (ImageLocationsConfig, error) {
-	r.logger.Tracef("Fetching Locations OCI Images for bundle: %s\n", bundleRef)
+	r.ui.Tracef("Fetching Locations OCI Images for bundle: %s\n", bundleRef)
 
 	locRef, err := r.locationsRefFromBundleRef(bundleRef)
 	if err != nil {
@@ -69,14 +71,14 @@ func (r LocationsConfigs) Fetch(registry ImagesMetadata, bundleRef name.Digest) 
 	if err != nil {
 		if terr, ok := err.(*transport.Error); ok {
 			if _, ok := imageNotFoundStatusCode[terr.StatusCode]; ok {
-				r.logger.Debugf("Did not find Locations OCI Image for bundle: %s\n", bundleRef)
+				r.ui.Debugf("Did not find Locations OCI Image for bundle: %s\n", bundleRef)
 				return ImageLocationsConfig{}, &LocationsNotFound{image: locRef.Name()}
 			}
 		}
 		return ImageLocationsConfig{}, fmt.Errorf("Fetching location image: %s", err)
 	}
 
-	r.logger.Tracef("Reading the locations configuration file\n")
+	r.ui.Tracef("Reading the locations configuration file\n")
 
 	cfg, err := r.reader.Read(img)
 	if err != nil {
@@ -87,7 +89,7 @@ func (r LocationsConfigs) Fetch(registry ImagesMetadata, bundleRef name.Digest) 
 }
 
 func (r LocationsConfigs) Save(reg ImagesMetadataWriter, bundleRef name.Digest, config ImageLocationsConfig, ui ui.UI) error {
-	r.logger.Tracef("saving Locations OCI Image for bundle: %s\n", bundleRef.Name())
+	r.ui.Tracef("saving Locations OCI Image for bundle: %s\n", bundleRef.Name())
 
 	locRef, err := r.locationsRefFromBundleRef(bundleRef)
 	if err != nil {
@@ -105,7 +107,7 @@ func (r LocationsConfigs) Save(reg ImagesMetadataWriter, bundleRef name.Digest, 
 		return err
 	}
 
-	r.logger.Tracef("Pushing image\n")
+	r.ui.Tracef("Pushing image\n")
 
 	_, err = plainimage.NewContents([]string{tmpDir}, nil).Push(locRef, nil, reg, ui)
 	if err != nil {

--- a/pkg/imgpkg/bundle/locations_configs_test.go
+++ b/pkg/imgpkg/bundle/locations_configs_test.go
@@ -9,6 +9,7 @@ import (
 	goui "github.com/cppforlife/go-cli-ui/ui"
 	regname "github.com/google/go-containerregistry/pkg/name"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
+	"github.com/k14s/imgpkg/pkg/imgpkg/util"
 	"github.com/k14s/imgpkg/test/helpers"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,12 @@ func TestLocations(t *testing.T) {
 		logger := &helpers.Logger{LogLevel: helpers.LogDebug}
 		fakeRegistryBuilder := helpers.NewFakeRegistry(t, logger)
 		fakeRegistry := fakeRegistryBuilder.Build()
-		subject := bundle.NewLocations(logger)
+
+		confUI := goui.NewConfUI(goui.NewNoopLogger())
+		defer confUI.Flush()
+		uiLogger := util.NewUILevelLogger(util.LogWarn, confUI)
+
+		subject := bundle.NewLocations(uiLogger)
 
 		bundleRef := fakeRegistryBuilder.ReferenceOnTestServer("some/testing@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93")
 		bundleDigestRef, err := regname.NewDigest(bundleRef)
@@ -55,7 +61,12 @@ func TestLocations(t *testing.T) {
 		logger := &helpers.Logger{LogLevel: helpers.LogDebug}
 		fakeRegistryBuilder := helpers.NewFakeRegistry(t, logger)
 		fakeRegistry := fakeRegistryBuilder.Build()
-		subject := bundle.NewLocations(logger)
+
+		confUI := goui.NewConfUI(goui.NewNoopLogger())
+		defer confUI.Flush()
+		uiLogger := util.NewUILevelLogger(util.LogWarn, confUI)
+
+		subject := bundle.NewLocations(uiLogger)
 
 		bundleRef := fakeRegistryBuilder.ReferenceOnTestServer("some/testing@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93")
 		bundleDigestRef, err := regname.NewDigest(bundleRef)

--- a/pkg/imgpkg/bundle/locations_configs_test.go
+++ b/pkg/imgpkg/bundle/locations_configs_test.go
@@ -16,8 +16,7 @@ import (
 
 func TestLocations(t *testing.T) {
 	t.Run("when creates a locations Images it can fetch the configuration", func(t *testing.T) {
-		logger := &helpers.Logger{LogLevel: helpers.LogDebug}
-		fakeRegistryBuilder := helpers.NewFakeRegistry(t, logger)
+		fakeRegistryBuilder := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		fakeRegistry := fakeRegistryBuilder.Build()
 
 		confUI := goui.NewConfUI(goui.NewNoopLogger())
@@ -58,8 +57,7 @@ func TestLocations(t *testing.T) {
 	})
 
 	t.Run("when locations Image is not present it returns LocationsNotFound error", func(t *testing.T) {
-		logger := &helpers.Logger{LogLevel: helpers.LogDebug}
-		fakeRegistryBuilder := helpers.NewFakeRegistry(t, logger)
+		fakeRegistryBuilder := helpers.NewFakeRegistry(t, &helpers.Logger{LogLevel: helpers.LogDebug})
 		fakeRegistry := fakeRegistryBuilder.Build()
 
 		confUI := goui.NewConfUI(goui.NewNoopLogger())

--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cppforlife/go-cli-ui/ui"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/k14s/imgpkg/pkg/imgpkg/bundle"
@@ -22,6 +23,8 @@ import (
 const rootBundleLabelKey string = "dev.carvel.imgpkg.copy.root-bundle"
 
 type CopyOptions struct {
+	ui ui.UI
+
 	ImageFlags      ImageFlags
 	BundleFlags     BundleFlags
 	LockInputFlags  LockInputFlags
@@ -36,8 +39,9 @@ type CopyOptions struct {
 	IncludeNonDistributable bool
 }
 
-func NewCopyOptions() *CopyOptions {
-	return &CopyOptions{}
+// NewCopyOptions constructor for building a CopyOptions, holding values derived via flags
+func NewCopyOptions(ui *ui.ConfUI) *CopyOptions {
+	return &CopyOptions{ui: ui}
 }
 
 func NewCopyCmd(o *CopyOptions) *cobra.Command {
@@ -89,7 +93,7 @@ func (c *CopyOptions) Run() error {
 	logger := util.NewLogger(os.Stderr)
 	prefixedLogger := logger.NewPrefixedWriter("copy | ")
 	levelLogger := logger.NewLevelLogger(util.LogWarn, prefixedLogger)
-	imagesUploaderLogger := logger.NewProgressBar(levelLogger, "done uploading images", "Error uploading images")
+	imagesUploaderLogger := util.NewProgressBar(c.ui, "done uploading images", "Error uploading images")
 
 	imageSet := ctlimgset.NewImageSet(c.Concurrency, prefixedLogger)
 	tarImageSet := ctlimgset.NewTarImageSet(imageSet, c.Concurrency, prefixedLogger)

--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cppforlife/go-cli-ui/ui"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
@@ -90,13 +89,13 @@ func (c *CopyOptions) Run() error {
 		return err
 	}
 
-	logger := util.NewLogger(os.Stderr)
-	prefixedLogger := logger.NewPrefixedWriter("copy | ")
-	levelLogger := logger.NewLevelLogger(util.LogWarn, prefixedLogger)
+	//logger := util.NewLogger(os.Stderr)
+	//prefixedLogger := logger.NewPrefixedWriter("copy | ")
+	//levelLogger := logger.NewLevelLogger(util.LogWarn, prefixedLogger)
 	imagesUploaderLogger := util.NewProgressBar(c.ui, "done uploading images", "Error uploading images")
 
-	imageSet := ctlimgset.NewImageSet(c.Concurrency, prefixedLogger)
-	tarImageSet := ctlimgset.NewTarImageSet(imageSet, c.Concurrency, prefixedLogger)
+	imageSet := ctlimgset.NewImageSet(c.Concurrency, c.ui)
+	tarImageSet := ctlimgset.NewTarImageSet(imageSet, c.Concurrency, c.ui)
 
 	var signatureRetriever SignatureRetriever
 	if c.SignatureFlags.CopyCosignSignatures {
@@ -104,6 +103,8 @@ func (c *CopyOptions) Run() error {
 	} else {
 		signatureRetriever = signature.NewNoop()
 	}
+
+	uiLogger := util.NewUILevelLogger(util.LogWarn, c.ui)
 
 	repoSrc := CopyRepoSrc{
 		ImageFlags:              c.ImageFlags,
@@ -113,7 +114,7 @@ func (c *CopyOptions) Run() error {
 		IncludeNonDistributable: c.IncludeNonDistributable,
 		Concurrency:             c.Concurrency,
 
-		logger:             levelLogger,
+		ui:                 uiLogger,
 		registry:           registry.NewRegistryWithProgress(reg, imagesUploaderLogger),
 		imageSet:           imageSet,
 		tarImageSet:        tarImageSet,
@@ -347,7 +348,7 @@ func everyMediaTypeForAnImage(image regv1.Image) []string {
 	return everyMediaType
 }
 
-func informUserToUseTheNonDistributableFlagWithDescriptors(logger util.LoggerWithLevels, includeNonDistributableFlag bool, everyMediaType []string) {
+func informUserToUseTheNonDistributableFlagWithDescriptors(ui util.UIWithLevels, includeNonDistributableFlag bool, everyMediaType []string) {
 	noNonDistributableLayers := true
 
 	for _, mediaType := range everyMediaType {
@@ -357,8 +358,8 @@ func informUserToUseTheNonDistributableFlagWithDescriptors(logger util.LoggerWit
 	}
 
 	if includeNonDistributableFlag && noNonDistributableLayers {
-		logger.Warnf("'--include-non-distributable-layers' flag provided, but no images contained a non-distributable layer.")
+		ui.Warnf("'--include-non-distributable-layers' flag provided, but no images contained a non-distributable layer.")
 	} else if !includeNonDistributableFlag && !noNonDistributableLayers {
-		logger.Warnf("Skipped layer due to it being non-distributable. If you would like to include non-distributable layers, use the --include-non-distributable-layers flag")
+		ui.Warnf("Skipped layer due to it being non-distributable. If you would like to include non-distributable layers, use the --include-non-distributable-layers flag")
 	}
 }

--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -89,13 +89,12 @@ func (c *CopyOptions) Run() error {
 		return err
 	}
 
-	//logger := util.NewLogger(os.Stderr)
-	//prefixedLogger := logger.NewPrefixedWriter("copy | ")
-	//levelLogger := logger.NewLevelLogger(util.LogWarn, prefixedLogger)
-	imagesUploaderLogger := util.NewProgressBar(c.ui, "done uploading images", "Error uploading images")
+	prefixedLogger := util.NewUIPrefixedWriter("copy | ", c.ui)
+	levelLogger := util.NewUILevelLogger(util.LogWarn, prefixedLogger)
+	imagesUploaderLogger := util.NewProgressBar(levelLogger, "done uploading images", "Error uploading images")
 
-	imageSet := ctlimgset.NewImageSet(c.Concurrency, c.ui)
-	tarImageSet := ctlimgset.NewTarImageSet(imageSet, c.Concurrency, c.ui)
+	imageSet := ctlimgset.NewImageSet(c.Concurrency, prefixedLogger)
+	tarImageSet := ctlimgset.NewTarImageSet(imageSet, c.Concurrency, prefixedLogger)
 
 	var signatureRetriever SignatureRetriever
 	if c.SignatureFlags.CopyCosignSignatures {
@@ -103,8 +102,6 @@ func (c *CopyOptions) Run() error {
 	} else {
 		signatureRetriever = signature.NewNoop()
 	}
-
-	uiLogger := util.NewUILevelLogger(util.LogWarn, c.ui)
 
 	repoSrc := CopyRepoSrc{
 		ImageFlags:              c.ImageFlags,
@@ -114,7 +111,7 @@ func (c *CopyOptions) Run() error {
 		IncludeNonDistributable: c.IncludeNonDistributable,
 		Concurrency:             c.Concurrency,
 
-		ui:                 uiLogger,
+		ui:                 levelLogger,
 		registry:           registry.NewRegistryWithProgress(reg, imagesUploaderLogger),
 		imageSet:           imageSet,
 		tarImageSet:        tarImageSet,

--- a/pkg/imgpkg/cmd/imgpkg.go
+++ b/pkg/imgpkg/cmd/imgpkg.go
@@ -46,7 +46,7 @@ func NewImgpkgCmd(o *ImgpkgOptions) *cobra.Command {
 	cmd.AddCommand(NewPushCmd(NewPushOptions(o.ui)))
 	cmd.AddCommand(NewPullCmd(NewPullOptions(o.ui)))
 	cmd.AddCommand(NewVersionCmd(NewVersionOptions(o.ui)))
-	cmd.AddCommand(NewCopyCmd(NewCopyOptions()))
+	cmd.AddCommand(NewCopyCmd(NewCopyOptions(o.ui)))
 
 	tagCmd := NewTagCmd()
 	tagCmd.AddCommand(NewTagListCmd(NewTagListOptions(o.ui)))

--- a/pkg/imgpkg/imageset/tar_image_set.go
+++ b/pkg/imgpkg/imageset/tar_image_set.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	goui "github.com/cppforlife/go-cli-ui/ui"
 	regname "github.com/google/go-containerregistry/pkg/name"
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagetar"
@@ -16,11 +17,12 @@ import (
 type TarImageSet struct {
 	imageSet    ImageSet
 	concurrency int
-	logger      Logger
+	ui          goui.UI
 }
 
-func NewTarImageSet(imageSet ImageSet, concurrency int, logger Logger) TarImageSet {
-	return TarImageSet{imageSet, concurrency, logger}
+// NewTarImageSet provides export/import operations on a tarball for a set of images
+func NewTarImageSet(imageSet ImageSet, concurrency int, ui goui.UI) TarImageSet {
+	return TarImageSet{imageSet, concurrency, ui}
 }
 
 func (i TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath string, registry ImagesReaderWriter, imageLayerWriterCheck imagetar.ImageLayerWriterFilter) (*imagedesc.ImageRefDescriptors, error) {
@@ -43,11 +45,11 @@ func (i TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath string
 		return os.OpenFile(outputPath, os.O_RDWR, 0755)
 	}
 
-	i.logger.WriteStr("writing layers...\n")
+	i.ui.BeginLinef("writing layers...\n")
 
 	opts := imagetar.TarWriterOpts{Concurrency: i.concurrency}
 
-	return ids, imagetar.NewTarWriter(ids, outputFileOpener, opts, i.logger, imageLayerWriterCheck).Write()
+	return ids, imagetar.NewTarWriter(ids, outputFileOpener, opts, i.ui, imageLayerWriterCheck).Write()
 }
 
 func (i *TarImageSet) Import(path string, importRepo regname.Repository, registry ImagesReaderWriter) (*ProcessedImages, error) {

--- a/pkg/imgpkg/imagetar/tar_writer.go
+++ b/pkg/imgpkg/imagetar/tar_writer.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"time"
 
+	goui "github.com/cppforlife/go-cli-ui/ui"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/k14s/imgpkg/pkg/imgpkg/imagedesc"
 	"github.com/k14s/imgpkg/pkg/imgpkg/util"
@@ -34,12 +35,13 @@ type TarWriter struct {
 	layersToWrite []imagedesc.ImageLayerDescriptor
 
 	opts                  TarWriterOpts
-	logger                Logger
+	ui                    goui.UI
 	imageLayerWriterCheck ImageLayerWriterFilter
 }
 
-func NewTarWriter(ids *imagedesc.ImageRefDescriptors, dstOpener func() (io.WriteCloser, error), opts TarWriterOpts, logger Logger, imageLayerWriterCheck ImageLayerWriterFilter) *TarWriter {
-	return &TarWriter{ids: ids, dstOpener: dstOpener, opts: opts, logger: logger, imageLayerWriterCheck: imageLayerWriterCheck}
+// NewTarWriter constructor returning a mechanism to write image refs / layers to a tarball on disk.
+func NewTarWriter(ids *imagedesc.ImageRefDescriptors, dstOpener func() (io.WriteCloser, error), opts TarWriterOpts, ui goui.UI, imageLayerWriterCheck ImageLayerWriterFilter) *TarWriter {
+	return &TarWriter{ids: ids, dstOpener: dstOpener, opts: opts, ui: ui, imageLayerWriterCheck: imageLayerWriterCheck}
 }
 
 func (w *TarWriter) Write() error {
@@ -302,7 +304,7 @@ func (w *TarWriter) writeTarEntry(tw *tar.Writer, path string, r io.Reader, size
 	}
 
 	if !zerosFill {
-		w.logger.WriteStr("done: file '%s' (%s)\n", path, time.Now().Sub(t1))
+		w.ui.BeginLinef("done: file '%s' (%s)\n", path, time.Now().Sub(t1))
 	}
 
 	return nil

--- a/pkg/imgpkg/util/level_logger.go
+++ b/pkg/imgpkg/util/level_logger.go
@@ -3,6 +3,8 @@
 
 package util
 
+import goui "github.com/cppforlife/go-cli-ui/ui"
+
 type LogLevel int
 
 type Logger interface {
@@ -18,11 +20,29 @@ type LoggerWithLevels interface {
 	Tracef(msg string, args ...interface{})
 }
 
+// UIWithLevels wraps a ui.UI with logging levels
+type UIWithLevels interface {
+	goui.UI
+
+	Errorf(msg string, args ...interface{})
+	Warnf(msg string, args ...interface{})
+	Debugf(msg string, args ...interface{})
+	Tracef(msg string, args ...interface{})
+}
+
 const (
 	LogTrace LogLevel = iota
 	LogDebug LogLevel = iota
 	LogWarn  LogLevel = iota
 )
+
+// NewUILevelLogger is a UILevelWriter constructor, wrapping a ui.UI with a specific log level
+func NewUILevelLogger(level LogLevel, ui goui.UI) *UILevelWriter {
+	return &UILevelWriter{
+		UI:       ui,
+		LogLevel: level,
+	}
+}
 
 func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger Logger) *LoggerLevelWriter {
 	return &LoggerLevelWriter{
@@ -34,6 +54,12 @@ func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger Logger) *LoggerLevel
 type LoggerLevelWriter struct {
 	LogLevel LogLevel
 	logger   Logger
+}
+
+// UILevelWriter allows specifying a log level to a ui.UI
+type UILevelWriter struct {
+	goui.UI
+	LogLevel LogLevel
 }
 
 func (l LoggerLevelWriter) Errorf(msg string, args ...interface{}) {
@@ -57,6 +83,36 @@ func (l LoggerLevelWriter) Debugf(msg string, args ...interface{}) {
 }
 
 func (l LoggerLevelWriter) Tracef(msg string, args ...interface{}) {
+	if l.LogLevel == LogTrace {
+		l.Logf(msg, args...)
+	}
+}
+
+// Errorf used to log error related messages
+func (l UILevelWriter) Errorf(msg string, args ...interface{}) {
+	l.Logf("Error: "+msg, args...)
+}
+// Warnf used to log warning related messages
+func (l UILevelWriter) Warnf(msg string, args ...interface{}) {
+	if l.LogLevel <= LogWarn {
+		l.Logf("Warning: "+msg, args...)
+	}
+}
+
+// Logf logs the provided message
+func (l UILevelWriter) Logf(msg string, args ...interface{}) {
+	l.BeginLinef(msg, args...)
+}
+
+// Debugf used to log debug related messages
+func (l UILevelWriter) Debugf(msg string, args ...interface{}) {
+	if l.LogLevel <= LogDebug {
+		l.Logf(msg, args...)
+	}
+}
+
+// Tracef used to log trace related messages
+func (l UILevelWriter) Tracef(msg string, args ...interface{}) {
 	if l.LogLevel == LogTrace {
 		l.Logf(msg, args...)
 	}

--- a/pkg/imgpkg/util/level_logger.go
+++ b/pkg/imgpkg/util/level_logger.go
@@ -5,20 +5,8 @@ package util
 
 import goui "github.com/cppforlife/go-cli-ui/ui"
 
+// LogLevel specifies logging level (i.e. DEBUG, WARN)
 type LogLevel int
-
-type Logger interface {
-	Logf(msg string, args ...interface{})
-}
-
-type LoggerWithLevels interface {
-	Logger
-
-	Errorf(msg string, args ...interface{})
-	Warnf(msg string, args ...interface{})
-	Debugf(msg string, args ...interface{})
-	Tracef(msg string, args ...interface{})
-}
 
 // UIWithLevels wraps a ui.UI with logging levels
 type UIWithLevels interface {
@@ -44,54 +32,17 @@ func NewUILevelLogger(level LogLevel, ui goui.UI) *UILevelWriter {
 	}
 }
 
-func (l ImgpkgLogger) NewLevelLogger(level LogLevel, logger Logger) *LoggerLevelWriter {
-	return &LoggerLevelWriter{
-		LogLevel: level,
-		logger:   logger,
-	}
-}
-
-type LoggerLevelWriter struct {
-	LogLevel LogLevel
-	logger   Logger
-}
-
 // UILevelWriter allows specifying a log level to a ui.UI
 type UILevelWriter struct {
 	goui.UI
 	LogLevel LogLevel
 }
 
-func (l LoggerLevelWriter) Errorf(msg string, args ...interface{}) {
-	l.Logf("Error: "+msg, args...)
-}
-
-func (l LoggerLevelWriter) Warnf(msg string, args ...interface{}) {
-	if l.LogLevel <= LogWarn {
-		l.Logf("Warning: "+msg, args...)
-	}
-}
-
-func (l LoggerLevelWriter) Logf(msg string, args ...interface{}) {
-	l.logger.Logf(msg, args...)
-}
-
-func (l LoggerLevelWriter) Debugf(msg string, args ...interface{}) {
-	if l.LogLevel <= LogDebug {
-		l.Logf(msg, args...)
-	}
-}
-
-func (l LoggerLevelWriter) Tracef(msg string, args ...interface{}) {
-	if l.LogLevel == LogTrace {
-		l.Logf(msg, args...)
-	}
-}
-
 // Errorf used to log error related messages
 func (l UILevelWriter) Errorf(msg string, args ...interface{}) {
 	l.Logf("Error: "+msg, args...)
 }
+
 // Warnf used to log warning related messages
 func (l UILevelWriter) Warnf(msg string, args ...interface{}) {
 	if l.LogLevel <= LogWarn {

--- a/pkg/imgpkg/util/level_logger_test.go
+++ b/pkg/imgpkg/util/level_logger_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/k14s/imgpkg/pkg/imgpkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -14,8 +15,7 @@ import (
 func TestLevelLogger(t *testing.T) {
 	t.Run("when log level is set to warn only write the warning message", func(t *testing.T) {
 		buf := bytes.Buffer{}
-		logger := util.NewLogger(&buf)
-		subject := logger.NewLevelLogger(util.LogWarn, logger.NewPrefixedWriter(""))
+		subject := util.NewUILevelLogger(util.LogWarn, util.NewUIPrefixedWriter("", ui.NewWriterUI(&buf, &buf, nil)))
 		subject.Warnf("warning message\n")
 		subject.Debugf("debug message\n")
 		subject.Tracef("trace message\n")
@@ -25,8 +25,7 @@ func TestLevelLogger(t *testing.T) {
 
 	t.Run("when log level is set to debug only write the warning and debug message", func(t *testing.T) {
 		buf := bytes.Buffer{}
-		logger := util.NewLogger(&buf)
-		subject := logger.NewLevelLogger(util.LogDebug, logger.NewPrefixedWriter(""))
+		subject := util.NewUILevelLogger(util.LogDebug, util.NewUIPrefixedWriter("", ui.NewWriterUI(&buf, &buf, nil)))
 		subject.Warnf("warning message\n")
 		subject.Debugf("debug message\n")
 		subject.Tracef("trace message\n")
@@ -36,8 +35,7 @@ func TestLevelLogger(t *testing.T) {
 
 	t.Run("when log level is set to trace only writes all messages", func(t *testing.T) {
 		buf := bytes.Buffer{}
-		logger := util.NewLogger(&buf)
-		subject := logger.NewLevelLogger(util.LogTrace, logger.NewPrefixedWriter(""))
+		subject := util.NewUILevelLogger(util.LogTrace, util.NewUIPrefixedWriter("", ui.NewWriterUI(&buf, &buf, nil)))
 		subject.Warnf("warning message\n")
 		subject.Debugf("debug message\n")
 		subject.Tracef("trace message\n")

--- a/pkg/imgpkg/util/logger_test.go
+++ b/pkg/imgpkg/util/logger_test.go
@@ -7,14 +7,15 @@ import (
 	"bytes"
 	"testing"
 
+	goui "github.com/cppforlife/go-cli-ui/ui"
 	"github.com/k14s/imgpkg/pkg/imgpkg/util"
 )
 
 func TestLogger(t *testing.T) {
 	var buf bytes.Buffer
 
-	logger := util.NewLogger(&buf)
-	prefLogger := logger.NewPrefixedWriter("prefix: ")
+	ui := goui.NewWriterUI(&buf, &buf, nil)
+	prefLogger := util.NewUIPrefixedWriter("prefix: ", ui)
 
 	prefLogger.Write([]byte("content1"))
 	prefLogger.Write([]byte("content2\n"))

--- a/test/e2e/copy_from_image_test.go
+++ b/test/e2e/copy_from_image_test.go
@@ -153,7 +153,7 @@ func TestCopyAnImageFromARepoToATarThatDoesNotContainNonDistributableLayersButTh
 	var imageDigest string
 	logger.Section("copy from a tarball (with a NDL) to a repo (the image in the repo does *not* include the NDL because the --include-non-dist flag was omitted)", func() {
 		stderr := bytes.NewBufferString("")
-		imgpkg.RunWithOpts([]string{"copy", "--tar", tarFilePath, "--to-repo", repoToCopyName}, helpers.RunOpts{
+		imgpkg.RunWithOpts([]string{"copy", "--tty", "--tar", tarFilePath, "--to-repo", repoToCopyName}, helpers.RunOpts{
 			StderrWriter: stderr,
 		})
 		imageDigest = fmt.Sprintf("@%s", env.ImageFactory.ImageDigest(env.RelocationRepo))
@@ -238,7 +238,7 @@ func TestCopyRepoToTarAndThenCopyFromTarToRepo(t *testing.T) {
 			stopRegistryForAirgapTesting(t, env)
 
 			var stdOutWriter bytes.Buffer
-			imgpkg.RunWithOpts([]string{"copy", "--tar", tarFilePath, "--to-repo", repoToCopyName}, helpers.RunOpts{
+			imgpkg.RunWithOpts([]string{"copy", "--tty", "--tar", tarFilePath, "--to-repo", repoToCopyName}, helpers.RunOpts{
 				StdoutWriter: &stdOutWriter,
 				StderrWriter: &stdOutWriter,
 			})

--- a/test/e2e/copy_from_tar_test.go
+++ b/test/e2e/copy_from_tar_test.go
@@ -82,7 +82,7 @@ func TestCopyTarSrc(t *testing.T) {
 		tempBundleTarDir := env.Assets.CreateTempFolder("bundle-tar")
 		tempBundleTarFile := filepath.Join(tempBundleTarDir, "bundle-tar.tgz")
 		imgpkg.Run([]string{"copy", "-b", bundleInfo.RefDigest, "--to-tar", tempBundleTarFile})
-		imgpkg.RunWithOpts([]string{"copy", "--tar", tempBundleTarFile, "--to-repo", fakeRegistry.ReferenceOnTestServer("copied-bundle")}, helpers.RunOpts{
+		imgpkg.RunWithOpts([]string{"copy", "--tty", "--tar", tempBundleTarFile, "--to-repo", fakeRegistry.ReferenceOnTestServer("copied-bundle")}, helpers.RunOpts{
 			AllowError:   false,
 			StderrWriter: outputBuffer,
 			StdoutWriter: outputBuffer,


### PR DESCRIPTION
This is a WIP: Convert usages from logger -> goui.UI

TODO:
- [x] clean up WIP commits
- [x]  delete the logger.Logger code
- [x]  fix up comments made to constructors. try and provide a purpose for the types they are building

Authored-by: Dennis Leon <leonde@vmware.com>