### PR TITLE
Disable defaultDockerConfigProvider

### DIFF
--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -18,6 +18,11 @@ go mod tidy
 # Specifically, the docker config.json is loaded before cli flags (and maybe even IaaS metadata services)
 git apply ./hack/patch-k8s-pkg-credentialprovider.patch
 
+git diff --exit-code || {
+  echo 'found changes in the project. when expected none. exiting'
+  exit 1
+}
+
 # makes builds reproducible
 export CGO_ENABLED=0
 LDFLAGS="-X github.com/k14s/imgpkg/pkg/imgpkg/cmd.Version=$VERSION -buildid="

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,6 +16,11 @@ go mod tidy
 # Specifically, the docker config.json is loaded before cli flags (and maybe even IaaS metadata services)
 git apply ./hack/patch-k8s-pkg-credentialprovider.patch
 
+git diff --exit-code vendor/ || {
+  echo 'found changes in the project. when expected none. exiting'
+  exit 1
+}
+
 # export GOOS=linux GOARCH=amd64
 go build -ldflags="$LDFLAGS" -trimpath -o imgpkg ./cmd/imgpkg/...
 ./imgpkg version

--- a/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
+++ b/vendor/github.com/vdemeester/k8s-pkg-credentialprovider/provider.go
@@ -70,7 +70,7 @@ type CachingDockerConfigProvider struct {
 
 // Enabled implements dockerConfigProvider
 func (d *defaultDockerConfigProvider) Enabled() bool {
-	return true
+	return false
 }
 
 // Provide implements dockerConfigProvider


### PR DESCRIPTION
- It was enabled by dependabot. When tests are run a git patch is
applied which is why the tests passed on the dependabot PR

Authored-by: Dennis Leon <leonde@vmware.com>