### PR TITLE
ux: improve error message when timeout occurs trying to auth via IaaS

### DIFF
--- a/pkg/imgpkg/registry/auth/iaas_keychain.go
+++ b/pkg/imgpkg/registry/auth/iaas_keychain.go
@@ -61,7 +61,7 @@ func NewIaasKeychain(ctx context.Context, environFunc func() []string) (authn.Ke
 			keyring: keyring,
 		}, nil
 	case <-timeout.Done():
-		return nil, fmt.Errorf("Timeout occurred trying to enable iaas provider")
+		return nil, fmt.Errorf("Timeout occurred trying to enable IaaS provider. (hint: To skip authenticating via IaaS set the environment variable IMGPKG_ENABLE_IAAS_AUTH=false)")
 	}
 }
 

--- a/pkg/imgpkg/registry/auth/iaas_keychain_test.go
+++ b/pkg/imgpkg/registry/auth/iaas_keychain_test.go
@@ -42,7 +42,7 @@ func TestTimeoutWhenEnablingProvider(t *testing.T) {
 			})
 
 			if assert.Error(t, err) {
-				assert.Equal(t, "Timeout occurred trying to enable iaas provider", err.Error())
+				assert.Equal(t, "Timeout occurred trying to enable IaaS provider. (hint: To skip authenticating via IaaS set the environment variable IMGPKG_ENABLE_IAAS_AUTH=false)", err.Error())
 			}
 
 			return true


### PR DESCRIPTION
- hint around the feature flag to disable auth via IaaS

Authored-by: Dennis Leon <leonde@vmware.com>