### PR TITLE
Use cosign to sign release binary files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,37 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v1.3.0
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.0
+
+      # Install gcloud, do not specify authentication.
+      - uses: 'google-github-actions/setup-gcloud@v0.2.1'
+        with:
+          project_id: ${{ secrets.PROJECT_NAME }}
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0.3.1'
+        env:
+          PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          WORKLOAD_ID_POOL: ${{ secrets.WORKLOAD_ID_POOL }}
+          WORKLOAD_ID_POOL_PROVIDER: ${{ secrets.WORKLOAD_ID_POOL_PROVIDER }}
+          SERVICE_ACCOUNT_NAME: ${{ secrets.SERVICE_ACCOUNT_NAME }}
+        with:
+          token_format: 'access_token'
+          create_credentials_file: 'true'
+          workload_identity_provider: 'projects/${{ env.PROJECT_ID }}/locations/global/workloadIdentityPools/${{ env.WORKLOAD_ID_POOL }}/providers/${{ env.WORKLOAD_ID_POOL_PROVIDER }}'
+          service_account: ${{ env.SERVICE_ACCOUNT_NAME }}@${{ env.PROJECT_NAME }}.iam.gserviceaccount.com
+
+      - id: 'gcloud'
+        name: 'gcloud'
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb
         if: startsWith(github.ref, 'refs/tags/')
@@ -29,6 +55,11 @@ jobs:
           args: release --rm-dist --debug ${{ env.SKIP_PUBLISH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_ID: ${{ secrets.PROJECT_NAME }}
+          KEY_LOCATION: ${{ secrets.KEY_LOCATION }}
+          KEY_RING: ${{ secrets.KEY_RING }}
+          KEY_NAME: ${{ secrets.KEY_NAME }}
+          KEY_VERSION: ${{ secrets.KEY_VERSION }}
       - uses: actions/github-script@v4
         id: get-checksums-from-draft-release
         if: startsWith(github.ref, 'refs/tags/') && ${{ !env.ACT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,14 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write  # undocumented OIDC support.
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: sigstore/cosign-installer@main
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,9 @@ builds:
     ldflags:
       - -buildid=
       - -X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}
-
+    hooks:
+      post:
+        - sh -c "COSIGN_EXPERIMENTAL=1 cosign sign-blob --output  dist/imgpkg-{{ .Os }}-{{ .Arch }}.sig {{ .Path }} 2>&1 | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' > dist/imgpkg-{{ .Os }}-{{ .Arch }}.crt"
 archives:
   - format: binary
     name_template: "{{ .Binary }}"
@@ -43,6 +45,10 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 release:
+  extra_files:
+    - glob: dist/*.sig
+    - glob: dist/*.crt
+
   # Repo in which the release will be created.
   github:
     owner: vmware-tanzu

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,9 +27,14 @@ builds:
     ldflags:
       - -buildid=
       - -X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}
-    hooks:
-      post:
-        - sh -c "COSIGN_EXPERIMENTAL=1 cosign sign-blob --output  dist/imgpkg-{{ .Os }}-{{ .Arch }}.sig {{ .Path }} 2>&1 | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' > dist/imgpkg-{{ .Os }}-{{ .Arch }}.crt"
+
+signs:
+  - id: cosign
+    signature: "${artifact}.sig"
+    cmd: cosign
+    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    artifacts: binary
+
 archives:
   - format: binary
     name_template: "{{ .Binary }}"
@@ -46,8 +51,7 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 release:
   extra_files:
-    - glob: dist/*.sig
-    - glob: dist/*.crt
+    - glob: "*.sig"
 
   # Repo in which the release will be created.
   github:


### PR DESCRIPTION
- Attaches the signature and public key required to verify the binary file

Example release: https://github.com/DennisDenuto/carvel-imgpkg/releases/tag/v0.40.0

TODO:
- [x] Also sign via github, use a carvel owned private/public key. Each carvel tool would require its own public key to be provided to verify all-the-blobs across multiple versions.
- [x] find out if verify-blob using keyless has a simpler way to find the public key (similar to how sign works)
- [x] Pin to a specific version of cosign-installer (instead of main)
- [x] figure out why windows signature file didn't get uploaded (but the windows crt and other distro signatures did)

Authored-by: Dennis Leon <leonde@vmware.com>