### PR TITLE
Reuse transport when talking with registries

### DIFF
--- a/pkg/imgpkg/registry/transport.go
+++ b/pkg/imgpkg/registry/transport.go
@@ -1,0 +1,89 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	regname "github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// RoundTripperStorage Maintains a storage of all the available RoundTripper for different registries and repositories
+type RoundTripperStorage struct {
+	baseRoundTripper http.RoundTripper
+	transports       map[string]map[string]map[string]http.RoundTripper
+	readWriteAccess  *sync.Mutex
+}
+
+// NewRoundTripperStorage Creates a struct that holds RoundTripper
+func NewRoundTripperStorage(baseRoundTripper http.RoundTripper) *RoundTripperStorage {
+	return &RoundTripperStorage{
+		baseRoundTripper: baseRoundTripper,
+		readWriteAccess:  &sync.Mutex{},
+		transports:       map[string]map[string]map[string]http.RoundTripper{},
+	}
+}
+
+// RoundTripper Retrieve the RoundTripper to be used for a particular registry and repository or nil if it cannot be found
+func (r *RoundTripperStorage) RoundTripper(repo regname.Repository, method string) http.RoundTripper {
+	r.readWriteAccess.Lock()
+	defer r.readWriteAccess.Unlock()
+
+	if _, ok := r.transports[repo.RegistryStr()]; !ok {
+		return nil
+	}
+
+	if _, ok := r.transports[repo.RegistryStr()][repo.RepositoryStr()]; !ok {
+		return nil
+	}
+
+	if _, ok := r.transports[repo.RegistryStr()][repo.RepositoryStr()][method]; !ok {
+		if method == transport.PullScope {
+			if _, ok := r.transports[repo.RegistryStr()][repo.RepositoryStr()][transport.PushScope]; ok {
+				return r.transports[repo.RegistryStr()][repo.RepositoryStr()][transport.PushScope]
+			}
+		}
+		return nil
+	}
+
+	return r.transports[repo.RegistryStr()][repo.RepositoryStr()][method]
+}
+
+// CreateRoundTripper Creates a new RoundTripper
+// scope field has the following format "repository:/org/suborg/repo_name:pull,push"
+//   for more information check https://github.com/distribution/distribution/blob/263da70ea6a4e96f61f7a6770273ec6baac38941/docs/spec/auth/token.md#requesting-a-token
+func (r *RoundTripperStorage) CreateRoundTripper(reg regname.Registry, auth authn.Authenticator, scope string) (http.RoundTripper, error) {
+	r.readWriteAccess.Lock()
+	defer r.readWriteAccess.Unlock()
+
+	rt, err := transport.NewWithContext(context.Background(), reg, auth, r.baseRoundTripper, []string{scope})
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create round tripper: %s", err)
+	}
+
+	if _, ok := r.transports[reg.RegistryStr()]; !ok {
+		r.transports[reg.RegistryStr()] = map[string]map[string]http.RoundTripper{}
+	}
+	s := strings.Split(scope, ":")
+	if len(s) != 3 {
+		panic(fmt.Sprintf("Internal inconsistency: expected scope '%s' to have 3 fields", scope))
+	}
+	// Maybe we should check to make sure only 1 repository is present in the scopes
+	repository := s[1]
+	method := s[2]
+
+	if _, ok := r.transports[reg.RegistryStr()][repository]; !ok {
+		r.transports[reg.RegistryStr()][repository] = map[string]http.RoundTripper{}
+	}
+
+	r.transports[reg.RegistryStr()][repository][method] = rt
+
+	return rt, nil
+}

--- a/pkg/imgpkg/registry/with_progress.go
+++ b/pkg/imgpkg/registry/with_progress.go
@@ -16,31 +16,38 @@ func NewRegistryWithProgress(reg Registry, logger util.ProgressLogger) *WithProg
 	return &WithProgress{delegate: reg, logger: logger}
 }
 
+// WithProgress Implements Registry interface and provides progress updates to the logger
 type WithProgress struct {
 	delegate Registry
 	logger   util.ProgressLogger
 }
 
-func (w WithProgress) Get(reference regname.Reference) (*remote.Descriptor, error) {
+// Get Retrieve Image descriptor for an Image reference
+func (w *WithProgress) Get(reference regname.Reference) (*remote.Descriptor, error) {
 	return w.delegate.Get(reference)
 }
 
-func (w WithProgress) Digest(reference regname.Reference) (regv1.Hash, error) {
+// Digest Retrieve the Digest for an Image reference
+func (w *WithProgress) Digest(reference regname.Reference) (regv1.Hash, error) {
 	return w.delegate.Digest(reference)
 }
 
-func (w WithProgress) Index(reference regname.Reference) (regv1.ImageIndex, error) {
+// Index Retrieve regv1.ImageIndex struct for an Index reference
+func (w *WithProgress) Index(reference regname.Reference) (regv1.ImageIndex, error) {
 	return w.delegate.Index(reference)
 }
 
-func (w WithProgress) Image(reference regname.Reference) (regv1.Image, error) {
+// Image Retrieve the regv1.Image struct for an Image reference
+func (w *WithProgress) Image(reference regname.Reference) (regv1.Image, error) {
 	return w.delegate.Image(reference)
 }
 
-func (w WithProgress) FirstImageExists(digests []string) (string, error) {
+// FirstImageExists Returns the first of the provided Image Digests that exists in the Registry
+func (w *WithProgress) FirstImageExists(digests []string) (string, error) {
 	return w.delegate.FirstImageExists(digests)
 }
 
+// MultiWrite Upload multiple Images in Parallel to the Registry
 func (w *WithProgress) MultiWrite(imageOrIndexesToUpload map[regname.Reference]remote.Taggable, concurrency int, _ chan regv1.Update) error {
 	uploadProgress := make(chan regv1.Update)
 	w.logger.Start(uploadProgress)
@@ -49,20 +56,23 @@ func (w *WithProgress) MultiWrite(imageOrIndexesToUpload map[regname.Reference]r
 	return w.delegate.MultiWrite(imageOrIndexesToUpload, concurrency, uploadProgress)
 }
 
-func (w WithProgress) WriteImage(reference regname.Reference, image regv1.Image) error {
+// WriteImage Upload Image to registry
+func (w *WithProgress) WriteImage(reference regname.Reference, image regv1.Image) error {
 	return w.delegate.WriteImage(reference, image)
 }
 
-func (w WithProgress) WriteIndex(reference regname.Reference, index regv1.ImageIndex) error {
+// WriteIndex Uploads the Index manifest to the registry
+func (w *WithProgress) WriteIndex(reference regname.Reference, index regv1.ImageIndex) error {
 	return w.delegate.WriteIndex(reference, index)
 }
 
-func (w WithProgress) WriteTag(tag regname.Tag, taggable remote.Taggable) error {
+// WriteTag Tag the referenced Image
+func (w *WithProgress) WriteTag(tag regname.Tag, taggable remote.Taggable) error {
 	return w.delegate.WriteTag(tag, taggable)
 }
 
 // ListTags Retrieve all tags associated with a Repository
-func (w WithProgress) ListTags(repo regname.Repository) ([]string, error) {
+func (w *WithProgress) ListTags(repo regname.Repository) ([]string, error) {
 	return w.delegate.ListTags(repo)
 }
 


### PR DESCRIPTION
This PR adds makes an improvement on the communication with the registries. Previously for each request done to the registry, a new transport was created. The main issue is that the authentication part was lost between requests.
We are introducing a store that will maintain the transport information that will be reused whenever possible, this will lower the number of times that `imgpkg` needs to talk with authentication servers.