### PR TITLE
Avoid overwriting user defined registry options

### DIFF
--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -157,7 +157,8 @@ func (r SimpleRegistry) CloneWithSingleAuth(imageRef regname.Tag) (Registry, err
 
 // opts Returns the opts + the keychain
 func (r SimpleRegistry) opts() []regremote.Option {
-	return append(r.remoteOpts, regremote.WithAuthFromKeychain(r.keychain))
+	// new options come first so that user configured options take precedence
+	return append([]regremote.Option{regremote.WithAuthFromKeychain(r.keychain)}, r.remoteOpts...)
 }
 
 // Get Retrieve Image descriptor for an Image reference


### PR DESCRIPTION
When defining default registry options, prepend them to the list of
existing options rather than append. Within GGCR when the options are
collected, items later in the list supersede items earlier in the list.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>