### PR TITLE
Flag `--cosign-artifacts` on describe command

### DIFF
--- a/pkg/imgpkg/bundle/describe.go
+++ b/pkg/imgpkg/bundle/describe.go
@@ -56,8 +56,9 @@ type Description struct {
 
 // DescribeOpts Options used when calling the Describe function
 type DescribeOpts struct {
-	Logger      Logger
-	Concurrency int
+	Logger                 Logger
+	Concurrency            int
+	IncludeCosignArtifacts bool
 }
 
 // SignatureFetcher Interface to retrieve signatures associated with Images
@@ -72,7 +73,12 @@ func Describe(bundleImage string, opts DescribeOpts, registryOpts registry.Opts)
 		return Description{}, err
 	}
 
-	signatureRetriever := signature.NewSignatures(signature.NewCosign(reg), opts.Concurrency)
+	var signatureRetriever SignatureFetcher
+	if !opts.IncludeCosignArtifacts {
+		signatureRetriever = signature.NewNoop()
+	} else {
+		signatureRetriever = signature.NewSignatures(signature.NewCosign(reg), opts.Concurrency)
+	}
 
 	return DescribeWithRegistryAndSignatureFetcher(bundleImage, opts, reg, signatureRetriever)
 }

--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -27,8 +27,9 @@ type DescribeOptions struct {
 	BundleFlags   BundleFlags
 	RegistryFlags RegistryFlags
 
-	Concurrency int
-	OutputType  string
+	Concurrency            int
+	OutputType             string
+	IncludeCosignArtifacts bool
 }
 
 // NewDescribeOptions constructor for building a DescribeOptions, holding values derived via flags
@@ -51,6 +52,7 @@ func NewDescribeCmd(o *DescribeOptions) *cobra.Command {
 	o.RegistryFlags.Set(cmd)
 	cmd.Flags().IntVar(&o.Concurrency, "concurrency", 5, "Concurrency")
 	cmd.Flags().StringVarP(&o.OutputType, "output-type", "o", "text", "Type of output possible values: [text, yaml]")
+	cmd.Flags().BoolVar(&o.IncludeCosignArtifacts, "cosign-artifacts", true, "Retrieve cosign artifact information (Default: true)")
 	return cmd
 }
 
@@ -65,8 +67,9 @@ func (d *DescribeOptions) Run() error {
 	description, err := bundle.Describe(
 		d.BundleFlags.Bundle,
 		bundle.DescribeOpts{
-			Logger:      levelLogger,
-			Concurrency: d.Concurrency,
+			Logger:                 levelLogger,
+			Concurrency:            d.Concurrency,
+			IncludeCosignArtifacts: d.IncludeCosignArtifacts,
 		},
 		d.RegistryFlags.AsRegistryOpts())
 	if err != nil {

--- a/pkg/imgpkg/signature/fetch_signatures.go
+++ b/pkg/imgpkg/signature/fetch_signatures.go
@@ -116,3 +116,8 @@ func NewNoop() *Noop { return &Noop{} }
 func (n Noop) Fetch(*imageset.UnprocessedImageRefs) (*imageset.UnprocessedImageRefs, error) {
 	return imageset.NewUnprocessedImageRefs(), nil
 }
+
+// FetchForImageRefs Retrieve the available signatures associated with the images provided
+func (n Noop) FetchForImageRefs(images []lockconfig.ImageRef) ([]lockconfig.ImageRef, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Add a flag to do not retrieve cosign artifacts while describing bundle