### PR TITLE
Images Location not correctly created

### DIFF
--- a/pkg/imgpkg/bundle/bundle.go
+++ b/pkg/imgpkg/bundle/bundle.go
@@ -71,8 +71,15 @@ func NewBundleWithReader(ref string, imagesMetadata ImagesMetadata, imagesLockRe
 
 // DigestRef Bundle full location including registry, repository and digest
 func (o *Bundle) DigestRef() string { return o.plainImg.DigestRef() }
-func (o *Bundle) Repo() string      { return o.plainImg.Repo() }
-func (o *Bundle) Tag() string       { return o.plainImg.Tag() }
+
+// Digest Bundle Digest
+func (o *Bundle) Digest() string { return o.plainImg.Digest() }
+
+// Repo Bundle registry and Repository
+func (o *Bundle) Repo() string { return o.plainImg.Repo() }
+
+// Tag Bundle Tag
+func (o *Bundle) Tag() string { return o.plainImg.Tag() }
 
 func (o *Bundle) updateCachedImageRefWithoutAnnotations(ref ImageRef) {
 	imgRef, found := o.cachedImageRefs.ImageRef(ref.Image)

--- a/pkg/imgpkg/bundle/bundle_images_lock.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock.go
@@ -69,8 +69,9 @@ func (o *Bundle) UpdateImageRefs(bundles []*Bundle) error {
 	for _, image := range imageRefsToProcess.ImageRefs() {
 		isBundle := false
 		for _, bundle := range bundles {
-			if bundle.DigestRef() == image.ImageRef.Image {
+			if bundle.Digest() == image.Digest() {
 				isBundle = true
+				image.ImageType = BundleImage
 				break
 			}
 		}

--- a/pkg/imgpkg/bundle/images_refs.go
+++ b/pkg/imgpkg/bundle/images_refs.go
@@ -60,6 +60,16 @@ func NewImageRefWithType(imgRef lockconfig.ImageRef, imageType ImageType) ImageR
 	return ImageRef{ImageRef: imgRef, IsBundle: &isBundle, Copiable: copiable, ImageType: imageType}
 }
 
+// Digest Image Digest
+func (i ImageRef) Digest() string {
+	digest, err := name.NewDigest(i.Image)
+	if err != nil {
+		panic(fmt.Sprintf("Internal inconsistency, ImageRef.Image '%s' should contain a digest", i.Image))
+	}
+
+	return digest.DigestStr()
+}
+
 func (i ImageRef) DeepCopy() ImageRef {
 	var isBundle *bool
 	if i.IsBundle != nil {

--- a/pkg/imgpkg/plainimage/plain_image.go
+++ b/pkg/imgpkg/plainimage/plain_image.go
@@ -77,6 +77,17 @@ func (i *PlainImage) DigestRef() string {
 	return i.parsedRef.Context().Name() + "@" + i.parsedDigest
 }
 
+// Digest Image Digest
+func (i *PlainImage) Digest() string {
+	if i.parsedRef == nil {
+		panic("Unexpected usage of Digest(); call Fetch before")
+	}
+	if len(i.parsedDigest) == 0 {
+		panic("Unexpected usage of Digest(); call Fetch before")
+	}
+	return i.parsedDigest
+}
+
 func (i *PlainImage) Tag() string {
 	if i.parsedRef == nil {
 		panic("Unexpected usage of Tag(); call Fetch before")


### PR DESCRIPTION
When Nested Bundles are not in the same repository as the Outer Bundle,
imgpkg was incorrectly relying on the Full Described Name of the Bundle
to find if it is a Bundle or not.

This only affected copy from tar to repository

Fixes #350 