### PR TITLE
Add a new struct builder for the SimpleRegistry

### DIFF
--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -93,12 +93,16 @@ type SimpleRegistry struct {
 }
 
 // NewSimpleRegistry Builder for a Simple Registry
-func NewSimpleRegistry(opts Opts, regOpts ...regremote.Option) (*SimpleRegistry, error) {
+func NewSimpleRegistry(opts Opts) (*SimpleRegistry, error) {
 	httpTran, err := newHTTPTransport(opts)
 	if err != nil {
 		return nil, fmt.Errorf("Creating registry HTTP transport: %s", err)
 	}
+	return NewSimpleRegistryWithTransport(opts, httpTran)
+}
 
+// NewSimpleRegistryWithTransport Creates a new Simple Registry using the provided transport
+func NewSimpleRegistryWithTransport(opts Opts, httpTran *http.Transport, regOpts ...regremote.Option) (*SimpleRegistry, error) {
 	var refOpts []regname.Option
 	if opts.Insecure {
 		refOpts = append(refOpts, regname.Insecure)


### PR DESCRIPTION
Since imgpkg is not using regremote.Option parameter in the code, so we created a new function that represents that.

Created a new function that allows other project to provide their own transport to the registry

Fixes #362 