### PR TITLE
Separate messages for Copy and Push options regarding lock output flag

### DIFF
--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -76,7 +76,7 @@ func NewCopyCmd(o *CopyOptions) *cobra.Command {
 	o.ImageFlags.SetCopy(cmd)
 	o.BundleFlags.SetCopy(cmd)
 	o.LockInputFlags.Set(cmd)
-	o.LockOutputFlags.Set(cmd)
+	o.LockOutputFlags.SetOnCopy(cmd)
 	o.TarFlags.Set(cmd)
 	o.RegistryFlags.Set(cmd)
 	o.SignatureFlags.Set(cmd)

--- a/pkg/imgpkg/cmd/lock_output_flags.go
+++ b/pkg/imgpkg/cmd/lock_output_flags.go
@@ -11,7 +11,12 @@ type LockOutputFlags struct {
 	LockFilePath string
 }
 
-func (l *LockOutputFlags) Set(cmd *cobra.Command) {
+func (l *LockOutputFlags) SetOnCopy(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&l.LockFilePath, "lock-output", "",
 		"Location to output the generated lockfile. Option only available when using --bundle or --lock flags")
+}
+
+func (l *LockOutputFlags) SetOnPush(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&l.LockFilePath, "lock-output", "",
+		"Location to output the generated lockfile. Option only available when using --bundle flag")
 }

--- a/pkg/imgpkg/cmd/lock_output_flags.go
+++ b/pkg/imgpkg/cmd/lock_output_flags.go
@@ -11,11 +11,13 @@ type LockOutputFlags struct {
 	LockFilePath string
 }
 
+// SetOnCopy Sets the lock-output flag for Copy command
 func (l *LockOutputFlags) SetOnCopy(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&l.LockFilePath, "lock-output", "",
 		"Location to output the generated lockfile. Option only available when using --bundle or --lock flags")
 }
 
+// SetOnPush Sets the lock-output flag for Push command
 func (l *LockOutputFlags) SetOnPush(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&l.LockFilePath, "lock-output", "",
 		"Location to output the generated lockfile. Option only available when using --bundle flag")

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -43,7 +43,7 @@ func NewPushCmd(o *PushOptions) *cobra.Command {
 	}
 	o.ImageFlags.Set(cmd)
 	o.BundleFlags.Set(cmd)
-	o.LockOutputFlags.Set(cmd)
+	o.LockOutputFlags.SetOnPush(cmd)
 	o.FileFlags.Set(cmd)
 	o.RegistryFlags.Set(cmd)
 	return cmd


### PR DESCRIPTION
This PR is a response to issue #354. Different functions to create the Cobra flag for `push` and `copy` commands, each one with its own text.