### PR TITLE
gitignore all imgpkg binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-/imgpkg
-/imgpkg-darwin-amd64
-/imgpkg-darwin-arm64
-/imgpkg-linux-amd64
-/imgpkg-windows-amd64.exe
+/imgpkg*
 /tmp
 .DS_Store
 /test/e2e/assets/simple-app/empty-dir


### PR DESCRIPTION
`imgpkg-linux-arm64` wasn't being gitignored, resulting in the paranoid release checksum logic [failing](https://github.com/vmware-tanzu/carvel-imgpkg/runs/6374164124?check_suite_focus=true), since the subsequent builds would have a dirty working tree with `imgpkg-linux-arm64` untracked, and that gets [embedded into each binary in Go 1.18](https://tip.golang.org/doc/go1.18#go-version) 

```bash
./hack/build-binaries.sh 0.29.0
go version -m imgpkg-linux-amd64
> ...
> build   vcs.modified=false
./hack/build-binaries.sh 0.29.0
go version -m imgpkg-linux-amd64
> ...
> build   vcs.modified=true
```