### PR TITLE
remove buildid

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,6 @@ builds:
       - -trimpath
 
     ldflags:
-      - -buildid=
       - -X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}
 
 archives:

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -25,7 +25,7 @@ git diff --exit-code || {
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version=$VERSION"
 
 
 GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -trimpath -o imgpkg-darwin-amd64 ./cmd/imgpkg/...

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -4,7 +4,6 @@ set -e -x -u
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-buildid="
 
 go fmt ./cmd/... ./pkg/... ./test/...
 go mod vendor
@@ -22,7 +21,7 @@ git diff --exit-code vendor/github.com/vdemeester || {
 }
 
 # export GOOS=linux GOARCH=amd64
-go build -ldflags="$LDFLAGS" -trimpath -o "imgpkg${IMGPKG_BINARY_EXT-}" ./cmd/imgpkg/...
+go build -trimpath -o "imgpkg${IMGPKG_BINARY_EXT-}" ./cmd/imgpkg/...
 ./imgpkg version
 
 # compile tests, but do not run them: https://github.com/golang/go/issues/15513#issuecomment-839126426


### PR DESCRIPTION
it is no longer necessary for reproducible builds: https://github.com/golang/go/commit/aa680c0c49b55722a72ad3772e590cd2f9af541d