### PR TITLE
Don't dirty the working directory with release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
           set -e -x
           VERSION=`echo ${{ github.ref }}  | grep -Eo '[0-9].*'`
 
-          ./hack/build-binaries.sh "$VERSION" > ./go-checksums
-          cat ./go-checksums
-          diff ./go-checksums <(cat <<EOF
+          ./hack/build-binaries.sh "$VERSION" > /tmp/go-checksums
+          cat /tmp/go-checksums
+          diff /tmp/go-checksums <(cat <<EOF
           ${{steps.get-checksums-from-draft-release.outputs.result}}
           EOF
           )

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -21,7 +21,7 @@ git diff --exit-code vendor/github.com/vdemeester || {
 }
 
 # export GOOS=linux GOARCH=amd64
-go build -ldflags="$LDFLAGS" -trimpath -o "imgpkg${IMGPKG_BINARY_EXT-}" ./cmd/imgpkg/...
+go build -trimpath -o "imgpkg${IMGPKG_BINARY_EXT-}" ./cmd/imgpkg/...
 ./imgpkg version
 
 # compile tests, but do not run them: https://github.com/golang/go/issues/15513#issuecomment-839126426


### PR DESCRIPTION
This causes the binaries to record the dirty working directory in their version information

Also fixes hack/build.sh which had an undefined variable after https://github.com/vmware-tanzu/carvel-imgpkg/commit/714912cd8644c14f97251d716678de1da45037cc