### PR TITLE
Fix output issue on describe command

### DIFF
--- a/pkg/imgpkg/bundle/fetch_images.go
+++ b/pkg/imgpkg/bundle/fetch_images.go
@@ -10,6 +10,11 @@ import (
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/lockconfig"
 )
 
+// SignatureFetcher Interface to retrieve signatures associated with Images
+type SignatureFetcher interface {
+	FetchForImageRefs(images []lockconfig.ImageRef) ([]lockconfig.ImageRef, error)
+}
+
 // FetchAllImagesRefs returns a flat list of nested bundles and every image reference for a specific bundle
 func (o *Bundle) FetchAllImagesRefs(concurrency int, ui Logger, sigFetcher SignatureFetcher) ([]*Bundle, error) {
 	bundles, _, err := o.AllImagesLockRefs(concurrency, ui)

--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -82,7 +82,7 @@ func (d *DescribeOptions) Run() error {
 		p := bundleTextPrinter{logger: levelLogger}
 		p.Print(description)
 	} else if d.OutputType == "yaml" {
-		p := bundleYAMLPrinter{logger: levelLogger}
+		p := bundleYAMLPrinter{logger: util.NewUILevelLogger(logLevel, util.NewLoggerNoTTY(d.ui))}
 		return p.Print(description)
 	}
 	return nil

--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/internal/util"
+	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -62,11 +63,12 @@ func (d *DescribeOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	logLevel := util.LogWarn
 
-	levelLogger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(d.ui))
-	description, err := bundle.Describe(
+	levelLogger := util.NewUILevelLogger(logLevel, util.NewLogger(d.ui))
+	description, err := v1.Describe(
 		d.BundleFlags.Bundle,
-		bundle.DescribeOpts{
+		v1.DescribeOpts{
 			Logger:                 levelLogger,
 			Concurrency:            d.Concurrency,
 			IncludeCosignArtifacts: d.IncludeCosignArtifacts,
@@ -104,7 +106,7 @@ type bundleTextPrinter struct {
 	logger Logger
 }
 
-func (p bundleTextPrinter) Print(description bundle.Description) {
+func (p bundleTextPrinter) Print(description v1.Description) {
 	bundleRef, err := regname.ParseReference(description.Image)
 	if err != nil {
 		panic(fmt.Sprintf("Internal consistency: expected %s to be a digest reference", description.Image))
@@ -115,7 +117,7 @@ func (p bundleTextPrinter) Print(description bundle.Description) {
 	p.printerRec(description, p.logger, p.logger)
 }
 
-func (p bundleTextPrinter) printerRec(description bundle.Description, originalLogger Logger, logger Logger) {
+func (p bundleTextPrinter) printerRec(description v1.Description, originalLogger Logger, logger Logger) {
 	indentLogger := util.NewIndentedLogger(logger)
 	if len(description.Content.Bundles) == 0 && len(description.Content.Images) == 0 {
 		return
@@ -182,7 +184,7 @@ type bundleYAMLPrinter struct {
 	logger Logger
 }
 
-func (p bundleYAMLPrinter) Print(description bundle.Description) error {
+func (p bundleYAMLPrinter) Print(description v1.Description) error {
 	bundleRef, err := regname.ParseReference(description.Image)
 	if err != nil {
 		panic(fmt.Sprintf("Internal consistency: expected %s to be a digest reference", description.Image))


### PR DESCRIPTION
This PR contains 2 changes:
- Move the API calls that previously were in the bundle pkg to the API package in order to signal they are public and people can use them directly
- Fix the issue where `-o yaml` didn't output anything when `--tty=false`


Fixes #434 