### PR TITLE
Have describe command display digests of image layers

### DIFF
--- a/pkg/imgpkg/bundle/bundle.go
+++ b/pkg/imgpkg/bundle/bundle.go
@@ -96,6 +96,9 @@ func (o *Bundle) Tag() string { return o.plainImg.Tag() }
 // NestedBundles Provides information about the Graph of nested bundles associated with the current bundle
 func (o *Bundle) NestedBundles() []GraphNode { return o.cachedNestedBundleGraph }
 
+// ImagesMetadata returns ImagesMetadata
+func (o *Bundle) ImagesMetadata() ImagesMetadata { return o.imgRetriever }
+
 func (o *Bundle) updateCachedImageRefWithoutAnnotations(ref ImageRef) {
 	imgRef, found := o.cachedImageRefs.ImageRef(ref.Image)
 	img := ref.DeepCopy()

--- a/pkg/imgpkg/bundle/bundle.go
+++ b/pkg/imgpkg/bundle/bundle.go
@@ -96,9 +96,6 @@ func (o *Bundle) Tag() string { return o.plainImg.Tag() }
 // NestedBundles Provides information about the Graph of nested bundles associated with the current bundle
 func (o *Bundle) NestedBundles() []GraphNode { return o.cachedNestedBundleGraph }
 
-// ImagesMetadata returns ImagesMetadata
-func (o *Bundle) ImagesMetadata() ImagesMetadata { return o.imgRetriever }
-
 func (o *Bundle) updateCachedImageRefWithoutAnnotations(ref ImageRef) {
 	imgRef, found := o.cachedImageRefs.ImageRef(ref.Image)
 	img := ref.DeepCopy()

--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/internal/util"
-	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1"
+	v1 "github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -161,6 +161,8 @@ func (p bundleTextPrinter) printerRec(description v1.Description, originalLogger
 		}
 		annotations := image.Annotations
 		p.printAnnotations(annotations, util.NewIndentedLogger(indentLogger))
+		layers := image.Layers
+		p.printLayers(layers, util.NewIndentedLogger(indentLogger))
 	}
 }
 
@@ -176,6 +178,17 @@ func (p bundleTextPrinter) printAnnotations(annotations map[string]string, inden
 		sort.Strings(annotationKeys)
 		for _, key := range annotationKeys {
 			annIndentLogger.Logf("%s: %s\n", key, annotations[key])
+		}
+	}
+}
+
+func (p bundleTextPrinter) printLayers(layers []map[string]string, indentLogger Logger) {
+	if len(layers) > 0 {
+		indentLogger.Logf("Layers:\n")
+		layerIndentLogger := util.NewIndentedLogger(indentLogger)
+
+		for i := range layers {
+			layerIndentLogger.Logf(" - Digest: %s\n", layers[i]["digest"])
 		}
 	}
 }

--- a/pkg/imgpkg/v1/describe.go
+++ b/pkg/imgpkg/v1/describe.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	regname "github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/bundle"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/lockconfig"
 	"github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry"
@@ -175,8 +177,8 @@ func (r *refWithDescription) describeBundleRec(visitedImgs map[string]refWithDes
 
 				layers := []map[string]string{}
 
-				parsedImgRef, _ := regname.ParseReference(ref.Image)
-				v1Img, _ := newBundle.ImagesMetadata().Image(parsedImgRef)
+				parsedImgRef, _ := regname.ParseReference(ref.Image, regname.WeakValidation)
+				v1Img, _ := remote.Image(parsedImgRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 				imgLayers, _ := v1Img.Layers()
 				for _, imgLayer := range imgLayers {
 					digHash, _ := imgLayer.Digest()


### PR DESCRIPTION
go run cmd/imgpkg/imgpkg.go describe -b projects-stg.registry.vmware.com/tce/cert-manager@sha256:e321a8936343a3eb05676aa2cf5ba7b5a07a8867e94cab75bff68800fa6b0459 -o yaml

```
sha: sha256:e321a8936343a3eb05676aa2cf5ba7b5a07a8867e94cab75bff68800fa6b0459
content:
  images:
    sha256:4ab2982a220e1c719473d52d8463508422ab26e92664732bfc4d96b538af6b8a:
      annotations:
        kbld.carvel.dev/id: quay.io/jetstack/cert-manager-webhook:v1.9.1
        kbld.carvel.dev/origins: |
          - resolved:
              tag: v1.9.1
              url: quay.io/jetstack/cert-manager-webhook:v1.9.1
      image: quay.io/jetstack/cert-manager-webhook@sha256:4ab2982a220e1c719473d52d8463508422ab26e92664732bfc4d96b538af6b8a
      imageType: Image
      layers:
      - digest: sha256:b9f88661235d25835ef747dab426861d51c4e9923b92623d422d7ac58eb123e9
      - digest: sha256:acfb93fdd86951555e2f45fb3fb417b12ef444d4fb46c94121121c8c0ef57e75
      - digest: sha256:3037f5ce7599ba6fb57a17ff4aefca8cbbeb2a2ecc8363b24fdedc1fca74ccb7
      - digest: sha256:02efe101fd3a9234df2c84bfa72a7b1b71babdbc9ab16f6df7fada1487433f20
      origin: quay.io/jetstack/cert-manager-webhook@sha256:4ab2982a220e1c719473d52d8463508422ab26e92664732bfc4d96b538af6b8a
...
...
```