### PR TITLE
Remove workaround for windows for SystemCertPool utility

### DIFF
--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
-	"runtime"
 	"sync"
 	"time"
 

--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -464,19 +464,10 @@ func (r *SimpleRegistry) FirstImageExists(digests []string) (string, error) {
 func newHTTPTransport(opts Opts) (*http.Transport, error) {
 	var pool *x509.CertPool
 
-	// workaround for windows not returning system certs via x509.SystemCertPool() See: https://github.com/golang/go/issues/16736
-	// instead windows lazily fetches ca certificates (over the network) as needed during cert verification time.
-	// to opt-into that tls.Config.RootCAs is set to nil on windows.
-	if runtime.GOOS != "windows" {
-		var err error
-		pool, err = x509.SystemCertPool()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if runtime.GOOS == "windows" && len(opts.CACertPaths) > 0 {
-		pool = x509.NewCertPool()
+	var err error
+	pool, err = x509.SystemCertPool()
+	if err != nil {
+		return nil, err
 	}
 
 	if len(opts.CACertPaths) > 0 {


### PR DESCRIPTION
Signed-off-by: Vandana Pathak <pathakv@sjc-ubu-eng-127.vmware.com>

Fixes https://github.com/vmware-tanzu/carvel-imgpkg/issues/462