### PR TITLE
Speed up multi-image operations

### DIFF
--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -234,6 +234,7 @@ func (r SimpleRegistry) CloneWithLogger(_ util.ProgressLogger) Registry {
 		refOpts:         r.refOpts,
 		keychain:        r.keychain,
 		roundTrippers:   r.roundTrippers,
+		authn:           map[string]regauthn.Authenticator{},
 		transportAccess: &sync.Mutex{},
 	}
 }
@@ -276,6 +277,10 @@ func (r *SimpleRegistry) transport(ref regname.Reference, scope string) (http.Ro
 		}
 	}
 
+	if r.authn == nil {
+		// This shouldn't happen, but let's defend in depth
+		r.authn = map[string]regauthn.Authenticator{}
+	}
 	auth, ok := r.authn[registry.Name()]
 	if !ok {
 		regauth, err := r.keychain.Resolve(registry)


### PR DESCRIPTION
Fixes #483

It turns out that if you pass a fresh keychain into ggcr, it will attempt to resolve the keychain each time, and doesn't keep a per-registry cache.  Add a per-registry authentication cache to the per-registry transport cache.

On a "verify-only" copy of 214 images and 7.06GiB, this reduced time from about 20 minutes to about 3 minutes. Will go back and grab "before" timing in a moment.

```
Succeeded

real	2m53.102s
user	0m2.926s
sys	0m2.721s
```

**Note: I've never touched this code before, so you may want to give this PR extra scrutiny**
