### PR TITLE
Add max-depth flag to describe

### DIFF
--- a/pkg/imgpkg/bundle/bundle_images_lock_test.go
+++ b/pkg/imgpkg/bundle/bundle_images_lock_test.go
@@ -452,7 +452,7 @@ func TestBundle_AllImagesLock_NoLocations_AllImagesCollocated(t *testing.T) {
 				fmt.Println("============")
 
 				subject, metrics := subTest.subjectCreator.BuildSubject(t, registryFakeBuilder, topBundleInfo, fakeImagesLockReader)
-				bundles, imagesRefs, err := subject.AllImagesLockRefs(6, uiLogger)
+				bundles, imagesRefs, err := subject.AllImagesLockRefs(6, bundle.NoDepthLimit, uiLogger)
 				require.NoError(t, err)
 
 				runAssertions(t, test.assertions, imagesRefs, imagesTree)
@@ -729,7 +729,7 @@ func TestBundle_AllImagesLock_NoLocations_ImagesNotCollocated(t *testing.T) {
 			metrics.AddMetricsHandler(registryFakeBuilder)
 
 			subject := bundle.NewBundleFromRef(topBundleInfo, reg, fakeImagesLockReader, bundle.NewRegistryFetcher(reg, fakeImagesLockReader))
-			bundles, imagesRefs, err := subject.AllImagesLockRefs(1, uiLogger)
+			bundles, imagesRefs, err := subject.AllImagesLockRefs(1, bundle.NoDepthLimit, uiLogger)
 			require.NoError(t, err)
 
 			runAssertions(t, test.assertions, imagesRefs, imagesTree)
@@ -1168,7 +1168,7 @@ func TestBundle_AllImagesLock_Locations_AllImagesCollocated(t *testing.T) {
 				fmt.Println("============")
 
 				subject, metrics := subTest.subjectCreator.BuildSubject(t, registryFakeBuilder, topBundleInfo, fakeImagesLockReader)
-				bundles, imagesRefs, err := subject.AllImagesLockRefs(6, uiLogger)
+				bundles, imagesRefs, err := subject.AllImagesLockRefs(6, bundle.NoDepthLimit, uiLogger)
 				require.NoError(t, err)
 
 				runAssertions(t, test.assertions, imagesRefs, imagesTree)
@@ -1221,7 +1221,7 @@ func TestBundle_AllImagesLock_Locations_AllImagesCollocated(t *testing.T) {
 		metrics.AddMetricsHandler(registryFakeBuilder)
 
 		subject := bundle.NewBundleFromRef(topBundleInfo, reg, fakeImagesLockReader, bundle.NewRegistryFetcher(reg, fakeImagesLockReader))
-		bundles, _, err := subject.AllImagesLockRefs(6, uiLogger)
+		bundles, _, err := subject.AllImagesLockRefs(6, bundle.NoDepthLimit, uiLogger)
 		require.NoError(t, err)
 
 		checkBundlesPresence(t, bundles, imagesTree)

--- a/pkg/imgpkg/bundle/bundle_test.go
+++ b/pkg/imgpkg/bundle/bundle_test.go
@@ -857,7 +857,7 @@ func TestNoteCopy(t *testing.T) {
 		uiLogger := util.NewUILevelLogger(util.LogDebug, util.NewNoopLogger())
 
 		subject := bundle.NewBundleFromPlainImage(plainimage.NewFetchedPlainImageWithTag(rootBundle.RefDigest, "", rootBundle.Image), reg)
-		_, _, err = subject.AllImagesLockRefs(1, uiLogger)
+		_, _, err = subject.AllImagesLockRefs(1, bundle.NoDepthLimit, uiLogger)
 		require.NoError(t, err)
 
 		processedImages := imageset.NewProcessedImages()

--- a/pkg/imgpkg/bundle/fetch_images.go
+++ b/pkg/imgpkg/bundle/fetch_images.go
@@ -17,8 +17,8 @@ type SignatureFetcher interface {
 }
 
 // FetchAllImagesRefs returns a flat list of nested bundles and every image reference for a specific bundle
-func (o *Bundle) FetchAllImagesRefs(concurrency int, ui Logger, sigFetcher SignatureFetcher) ([]*Bundle, error) {
-	bundles, _, err := o.AllImagesLockRefs(concurrency, ui)
+func (o *Bundle) FetchAllImagesRefs(concurrency int, maxDepth int, ui Logger, sigFetcher SignatureFetcher) ([]*Bundle, error) {
+	bundles, _, err := o.AllImagesLockRefs(concurrency, maxDepth, ui)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imgpkg/cmd/copy_repo_src.go
+++ b/pkg/imgpkg/cmd/copy_repo_src.go
@@ -95,7 +95,7 @@ func (c CopyRepoSrc) CopyToRepo(repo string) (*ctlimgset.ProcessedImages, error)
 		}
 
 		if foundRootBundle {
-			bundles, _, err := parentBundle.AllImagesLockRefs(c.Concurrency, c.logger)
+			bundles, _, err := parentBundle.AllImagesLockRefs(c.Concurrency, ctlbundle.NoDepthLimit, c.logger)
 			if err != nil {
 				return nil, err
 			}
@@ -257,7 +257,7 @@ func (c CopyRepoSrc) getBundleImageRefs(bundleRef string) (*ctlbundle.Bundle, []
 		return nil, nil, ctlbundle.ImageRefs{}, fmt.Errorf("Expected bundle image but found plain image (hint: Did you use -i instead of -b?)")
 	}
 
-	nestedBundles, imageRefs, err := bundle.AllImagesLockRefs(c.Concurrency, c.logger)
+	nestedBundles, imageRefs, err := bundle.AllImagesLockRefs(c.Concurrency, ctlbundle.NoDepthLimit, c.logger)
 	if err != nil {
 		return nil, nil, ctlbundle.ImageRefs{}, fmt.Errorf("Reading Images from Bundle: %s", err)
 	}

--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -29,6 +29,7 @@ type DescribeOptions struct {
 	RegistryFlags RegistryFlags
 
 	Concurrency            int
+	MaxDepth               int
 	OutputType             string
 	IncludeCosignArtifacts bool
 }
@@ -52,6 +53,7 @@ func NewDescribeCmd(o *DescribeOptions) *cobra.Command {
 	o.BundleFlags.SetCopy(cmd)
 	o.RegistryFlags.Set(cmd)
 	cmd.Flags().IntVar(&o.Concurrency, "concurrency", 5, "Concurrency")
+	cmd.Flags().IntVar(&o.MaxDepth, "max-depth", 0, "Maximum recursion depth (0 is no limit)")
 	cmd.Flags().StringVarP(&o.OutputType, "output-type", "o", "text", "Type of output possible values: [text, yaml]")
 	cmd.Flags().BoolVar(&o.IncludeCosignArtifacts, "cosign-artifacts", true, "Retrieve cosign artifact information (Default: true)")
 	return cmd
@@ -71,6 +73,7 @@ func (d *DescribeOptions) Run() error {
 		v1.DescribeOpts{
 			Logger:                 levelLogger,
 			Concurrency:            d.Concurrency,
+			MaxDepth:               d.MaxDepth,
 			IncludeCosignArtifacts: d.IncludeCosignArtifacts,
 		},
 		d.RegistryFlags.AsRegistryOpts())

--- a/pkg/imgpkg/v1/describe.go
+++ b/pkg/imgpkg/v1/describe.go
@@ -61,6 +61,7 @@ type Description struct {
 type DescribeOpts struct {
 	Logger                 bundle.Logger
 	Concurrency            int
+	MaxDepth               int
 	IncludeCosignArtifacts bool
 }
 
@@ -98,7 +99,7 @@ func DescribeWithRegistryAndSignatureFetcher(bundleImage string, opts DescribeOp
 		return Description{}, fmt.Errorf("Only bundles can be described, and %s is not a bundle", bundleImage)
 	}
 
-	allBundles, err := newBundle.FetchAllImagesRefs(opts.Concurrency, opts.Logger, sigFetcher)
+	allBundles, err := newBundle.FetchAllImagesRefs(opts.Concurrency, opts.MaxDepth, opts.Logger, sigFetcher)
 	if err != nil {
 		return Description{}, fmt.Errorf("Retrieving Images from bundle: %s", err)
 	}
@@ -146,7 +147,7 @@ func (r *refWithDescription) describeBundleRec(visitedImgs map[string]refWithDes
 		}
 	}
 	if newBundle == nil {
-		panic(fmt.Sprintf("Internal consistency: bundle with ref '%s' could not be found in list of bundles", currentBundle.PrimaryLocation()))
+		return desc.bundle
 	}
 
 	imagesRefs := newBundle.ImagesRefsWithErrors()


### PR DESCRIPTION
When a bundle contains a large set of nested bundles the describe command on the root bundle can take a long time. 

This change introduces a `--max-depth` flag to the describe command in order to limit the depth of recursion that is performed on the bundle. This is similar to the `--no-recursion` flag discussed in #204 .