### PR TITLE
prefix version with v in building binaries while verifying artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: 1.16.2
-          args: release --rm-dist --debug ${{ env.SKIP_PUBLISH }}
+          args: release --clean --debug ${{ env.SKIP_PUBLISH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG_NAME }}
@@ -94,7 +94,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           set -e -x
-          VERSION=`echo ${{ github.ref }}  | grep -Eo '[0-9].*'`
+          VERSION=`echo ${{ github.ref }}  | grep -Eo 'v[0-9].*'`
 
           ./hack/build-binaries.sh "$VERSION" > /tmp/go-checksums
           cat /tmp/go-checksums


### PR DESCRIPTION
`v` is missing while providing version for building binaries in verify artifacts stage