### PR TITLE
stop giving v as version in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
       - -trimpath
 
     ldflags:
-      - -X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version=v{{ .Version }}
+      - -X github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/cmd.Version={{ .Version }}
 
 archives:
   - format: binary


### PR DESCRIPTION
remove `v` as prefix for version in goreleaser