### PR TITLE
Add support for OCI labels on image/bundle push

### DIFF
--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -49,6 +49,9 @@ func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry
 		return "", err
 	}
 
+	if labels == nil {
+		labels = map[string]string{}
+	}
 	labels[BundleConfigLabel] = "true"
 
 	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRef, labels, registry, logger)

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -49,6 +49,10 @@ func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry
 		return "", err
 	}
 
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
 	labels[BundleConfigLabel] = "true"
 	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRef, labels, registry, logger)
 }

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -43,13 +43,13 @@ func NewContents(paths []string, excludedPaths []string, preservePermissions boo
 }
 
 // Push the contents of the bundle to the registry as an OCI Image
-func (b Contents) Push(uploadRef regname.Tag, registry ImagesMetadataWriter, logger Logger) (string, error) {
+func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry ImagesMetadataWriter, logger Logger) (string, error) {
 	err := b.validate()
 	if err != nil {
 		return "", err
 	}
 
-	labels := map[string]string{BundleConfigLabel: "true"}
+	labels[BundleConfigLabel] = "true"
 	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRef, labels, registry, logger)
 }
 

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -49,11 +49,8 @@ func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry
 		return "", err
 	}
 
-	if labels == nil {
-		labels = map[string]string{}
-	}
-
 	labels[BundleConfigLabel] = "true"
+
 	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRef, labels, registry, logger)
 }
 

--- a/pkg/imgpkg/bundle/contents_test.go
+++ b/pkg/imgpkg/bundle/contents_test.go
@@ -44,7 +44,7 @@ images:
 			t.Fatalf("failed to read tag: %s", err)
 		}
 
-		_, err = subject.Push(imgTag, make(map[string]string), fakeRegistry, util.NewNoopLevelLogger())
+		_, err = subject.Push(imgTag, map[string]string{}, fakeRegistry, util.NewNoopLevelLogger())
 		if err != nil {
 			t.Fatalf("not expecting push to fail: %s", err)
 		}

--- a/pkg/imgpkg/bundle/contents_test.go
+++ b/pkg/imgpkg/bundle/contents_test.go
@@ -44,7 +44,7 @@ images:
 			t.Fatalf("failed to read tag: %s", err)
 		}
 
-		_, err = subject.Push(imgTag, fakeRegistry, util.NewNoopLevelLogger())
+		_, err = subject.Push(imgTag, make(map[string]string), fakeRegistry, util.NewNoopLevelLogger())
 		if err != nil {
 			t.Fatalf("not expecting push to fail: %s", err)
 		}
@@ -78,7 +78,7 @@ images:
 			t.Fatalf("failed to read tag: %s", err)
 		}
 
-		_, err = subject.Push(imgTag, fakeRegistry, util.NewNoopLevelLogger())
+		_, err = subject.Push(imgTag, map[string]string{}, fakeRegistry, util.NewNoopLevelLogger())
 		if err != nil {
 			t.Fatalf("not expecting push to fail: %s", err)
 		}

--- a/pkg/imgpkg/cmd/label_flags.go
+++ b/pkg/imgpkg/cmd/label_flags.go
@@ -7,10 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// LabelFlags is a struct that holds the labels for an OCI artifact
 type LabelFlags struct {
 	Labels map[string]string
 }
 
+// Set sets the labels for an OCI artifact
 func (l *LabelFlags) Set(cmd *cobra.Command) {
-	cmd.Flags().StringToStringVarP(&l.Labels, "labels", "l", make(map[string]string), "Set labels on image")
+	cmd.Flags().StringToStringVarP(&l.Labels, "labels", "l", map[string]string{}, "Set labels on image")
 }

--- a/pkg/imgpkg/cmd/label_flags.go
+++ b/pkg/imgpkg/cmd/label_flags.go
@@ -1,0 +1,16 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type LabelFlags struct {
+	Labels map[string]string
+}
+
+func (l *LabelFlags) Set(cmd *cobra.Command) {
+	cmd.Flags().StringToStringVarP(&l.Labels, "labels", "l", make(map[string]string), "Set labels on image")
+}

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -58,6 +58,11 @@ func (po *PushOptions) Run() error {
 		return err
 	}
 
+	err = po.validateFlags()
+	if err != nil {
+		return err
+	}
+
 	var imageURL string
 
 	isBundle := po.BundleFlags.Bundle != ""
@@ -144,4 +149,18 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
 	return plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.Labels, registry, logger)
+}
+
+// validateFlags checks if the provided flags are valid
+func (po *PushOptions) validateFlags() error {
+
+	// Verify the user did NOT specify a reserved OCI label
+	_, present := po.Labels[bundle.BundleConfigLabel]
+
+	if present {
+		return fmt.Errorf("label '%s' is reserved and cannot be overriden. Please use a different key", bundle.BundleConfigLabel)
+	}
+
+	return nil
+
 }

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -24,6 +24,7 @@ type PushOptions struct {
 	LockOutputFlags LockOutputFlags
 	FileFlags       FileFlags
 	RegistryFlags   RegistryFlags
+	Labels          map[string]string
 }
 
 func NewPushOptions(ui ui.UI) *PushOptions {
@@ -47,6 +48,7 @@ func NewPushCmd(o *PushOptions) *cobra.Command {
 	o.LockOutputFlags.SetOnPush(cmd)
 	o.FileFlags.Set(cmd)
 	o.RegistryFlags.Set(cmd)
+	cmd.Flags().StringToStringVarP(&o.Labels, "labels", "l", map[string]string{}, "Set labels on image")
 	return cmd
 }
 
@@ -96,7 +98,7 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 	}
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
-	imageURL, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, registry, logger)
+	imageURL, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.Labels, registry, logger)
 	if err != nil {
 		return "", err
 	}
@@ -141,5 +143,5 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 	}
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
-	return plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, nil, registry, logger)
+	return plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.Labels, registry, logger)
 }

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -24,7 +24,7 @@ type PushOptions struct {
 	LockOutputFlags LockOutputFlags
 	FileFlags       FileFlags
 	RegistryFlags   RegistryFlags
-	Labels          map[string]string
+	LabelFlags      LabelFlags
 }
 
 func NewPushOptions(ui ui.UI) *PushOptions {
@@ -48,7 +48,8 @@ func NewPushCmd(o *PushOptions) *cobra.Command {
 	o.LockOutputFlags.SetOnPush(cmd)
 	o.FileFlags.Set(cmd)
 	o.RegistryFlags.Set(cmd)
-	cmd.Flags().StringToStringVarP(&o.Labels, "labels", "l", map[string]string{}, "Set labels on image")
+	o.LabelFlags.Set(cmd)
+
 	return cmd
 }
 
@@ -67,6 +68,10 @@ func (po *PushOptions) Run() error {
 
 	isBundle := po.BundleFlags.Bundle != ""
 	isImage := po.ImageFlags.Image != ""
+
+	if po.LabelFlags.Labels == nil {
+		po.LabelFlags.Labels = map[string]string{}
+	}
 
 	switch {
 	case isBundle && isImage:
@@ -103,7 +108,7 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 	}
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
-	imageURL, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.Labels, registry, logger)
+	imageURL, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.LabelFlags.Labels, registry, logger)
 	if err != nil {
 		return "", err
 	}
@@ -148,14 +153,14 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 	}
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
-	return plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.Labels, registry, logger)
+	return plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.LabelFlags.Labels, registry, logger)
 }
 
 // validateFlags checks if the provided flags are valid
 func (po *PushOptions) validateFlags() error {
 
 	// Verify the user did NOT specify a reserved OCI label
-	_, present := po.Labels[bundle.BundleConfigLabel]
+	_, present := po.LabelFlags.Labels[bundle.BundleConfigLabel]
 
 	if present {
 		return fmt.Errorf("label '%s' is reserved and cannot be overriden. Please use a different key", bundle.BundleConfigLabel)

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -69,10 +69,6 @@ func (po *PushOptions) Run() error {
 	isBundle := po.BundleFlags.Bundle != ""
 	isImage := po.ImageFlags.Image != ""
 
-	if po.LabelFlags.Labels == nil {
-		po.LabelFlags.Labels = map[string]string{}
-	}
-
 	switch {
 	case isBundle && isImage:
 		return fmt.Errorf("Expected only one of image or bundle")

--- a/pkg/imgpkg/cmd/push_test.go
+++ b/pkg/imgpkg/cmd/push_test.go
@@ -11,8 +11,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/carvel-imgpkg/test/helpers"
 )
 
 const emptyImagesYaml = `apiVersion: imgpkg.carvel.dev/v1alpha1
@@ -232,6 +236,86 @@ func TestImageAndBundleLockError(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "Lock output is not compatible with image, use bundle for lock output") {
 		t.Fatalf("Expected error to contain message about invalid flags, got: %s", err)
+	}
+}
+
+func TestLabels(t *testing.T) {
+	testCases := []struct {
+		name           string
+		opType         string
+		expectedError  string
+		expectedLabels map[string]string
+		labelInput     string
+	}{
+		{
+			name:           "bundle with multiple labels",
+			opType:         "bundle",
+			expectedError:  "",
+			labelInput:     "foo=bar,bar=baz",
+			expectedLabels: map[string]string{"dev.carvel.imgpkg.bundle": "true", "foo": "bar", "bar": "baz"},
+		},
+		{
+			name:           "image with multiple labels",
+			opType:         "image",
+			expectedError:  "",
+			labelInput:     "foo=bar,bar=baz",
+			expectedLabels: map[string]string{"foo": "bar", "bar": "baz"},
+		},
+		{
+			name:           "bundle with \".\" in label key",
+			opType:         "bundle",
+			expectedError:  "",
+			labelInput:     "foo.bar=baz",
+			expectedLabels: map[string]string{"dev.carvel.imgpkg.bundle": "true", "foo.bar": "baz"},
+		},
+		{
+			name:           "bundle with long label key (> 64 chars)",
+			opType:         "bundle",
+			expectedError:  "",
+			labelInput:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=baz",
+			expectedLabels: map[string]string{"dev.carvel.imgpkg.bundle": "true", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "baz"},
+		},
+		{
+			name:           "bundle with long label value (> 256 chars)",
+			opType:         "bundle",
+			expectedError:  "",
+			labelInput:     "foo=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedLabels: map[string]string{"dev.carvel.imgpkg.bundle": "true", "foo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		},
+	}
+
+	for _, tc := range testCases {
+		f := func(t *testing.T) {
+			env := helpers.BuildEnv(t)
+			imgpkg := helpers.Imgpkg{T: t, ImgpkgPath: env.ImgpkgPath}
+			defer env.Cleanup()
+
+			opTypeFlag := "-b"
+			pushDir := env.BundleFactory.CreateBundleDir(helpers.BundleYAML, helpers.ImagesYAML)
+
+			if tc.opType == "image" {
+				opTypeFlag = "-i"
+				pushDir = env.Assets.CreateAndCopySimpleApp("image-to-push")
+			}
+
+			if tc.labelInput == "" {
+				imgpkg.Run([]string{"push", opTypeFlag, env.Image, "-f", pushDir})
+			} else {
+				imgpkg.Run([]string{"push", opTypeFlag, env.Image, "-l", tc.labelInput, "-f", pushDir})
+			}
+
+			ref, _ := name.NewTag(env.Image, name.WeakValidation)
+			image, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+			require.NoError(t, err)
+
+			config, err := image.ConfigFile()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedLabels, config.Config.Labels, "Expected labels provided via flags to match labels discovered on image")
+
+		}
+
+		t.Run(tc.name, f)
 	}
 }
 

--- a/pkg/imgpkg/cmd/push_test.go
+++ b/pkg/imgpkg/cmd/push_test.go
@@ -282,6 +282,13 @@ func TestLabels(t *testing.T) {
 			labelInput:     "foo=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			expectedLabels: map[string]string{"dev.carvel.imgpkg.bundle": "true", "foo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 		},
+		{
+			name:           "bundle with spaces in label value",
+			opType:         "bundle",
+			expectedError:  "",
+			labelInput:     "foo.bar=baz bar",
+			expectedLabels: map[string]string{"dev.carvel.imgpkg.bundle": "true", "foo.bar": "baz bar"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds the ability for users to specify OCI labels that will be added to the generated OCI artifact (bundle/image) during a `push` operation.

Fixes #153

Example: 

```shell
$ imgpkg push -b index.docker.io/jmsearcy/example-bundle:v1.0.3 -l foo.bar=baz -f ../../tmp/imgpkg-test
```

The resulting OCI artifact can be inspected as such to show the labels added:

```shell
$ regctl image inspect jmsearcy/example-bundle:v1.0.3

{
  "created": "0001-01-01T00:00:00Z",
  "architecture": "",
  "os": "",
  "config": {
    "Labels": {
      "dev.carvel.imgpkg.bundle": "true",
      "foo.bar": "baz",
    }
  },
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:f77fc57aa0878a70576e6b45c74ce5a7070219687b92fe073f632d71b7b107f8"
    ]
  },
  "history": [
    {
      "created": "0001-01-01T00:00:00Z",
      "created_by": "imgpkg",
      "author": "imgpkg"
    }
  ]
}
```