### PR TITLE
Add support to handle additional OCI tags from user input

### DIFF
--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -59,7 +59,6 @@ func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry
 
 // MultiTagPush pushes the OCI Bundle to the registry with multiple tags
 func (b Contents) MultiTagPush(uploadRefs []regname.Tag, labels map[string]string, registry ImagesMetadataWriter, logger Logger) (string, error) {
-
 	err := b.validate()
 	if err != nil {
 		return "", err

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -42,8 +42,8 @@ func NewContents(paths []string, excludedPaths []string, preservePermissions boo
 	return Contents{paths: paths, excludedPaths: excludedPaths, preservePermissions: preservePermissions}
 }
 
-// Push the contents of the bundle to the registry as an OCI Image
-func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry ImagesMetadataWriter, logger Logger) (string, error) {
+// Push the contents of the bundle to the registry as an OCI Image with one or more tags
+func (b Contents) Push(uploadRefs []regname.Tag, labels map[string]string, registry ImagesMetadataWriter, logger Logger) (string, error) {
 	err := b.validate()
 	if err != nil {
 		return "", err
@@ -54,22 +54,7 @@ func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry
 	}
 	labels[BundleConfigLabel] = "true"
 
-	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRef, labels, registry, logger)
-}
-
-// MultiTagPush pushes the OCI Bundle to the registry with multiple tags
-func (b Contents) MultiTagPush(uploadRefs []regname.Tag, labels map[string]string, registry ImagesMetadataWriter, logger Logger) (string, error) {
-	err := b.validate()
-	if err != nil {
-		return "", err
-	}
-
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	labels[BundleConfigLabel] = "true"
-
-	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).MultiTagPush(uploadRefs, labels, registry, logger)
+	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRefs, labels, registry, logger)
 }
 
 // PresentsAsBundle checks if the provided folders have the needed structure to be a bundle

--- a/pkg/imgpkg/bundle/contents.go
+++ b/pkg/imgpkg/bundle/contents.go
@@ -57,6 +57,22 @@ func (b Contents) Push(uploadRef regname.Tag, labels map[string]string, registry
 	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).Push(uploadRef, labels, registry, logger)
 }
 
+// MultiTagPush pushes the OCI Bundle to the registry with multiple tags
+func (b Contents) MultiTagPush(uploadRefs []regname.Tag, labels map[string]string, registry ImagesMetadataWriter, logger Logger) (string, error) {
+
+	err := b.validate()
+	if err != nil {
+		return "", err
+	}
+
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[BundleConfigLabel] = "true"
+
+	return plainimage.NewContents(b.paths, b.excludedPaths, b.preservePermissions).MultiTagPush(uploadRefs, labels, registry, logger)
+}
+
 // PresentsAsBundle checks if the provided folders have the needed structure to be a bundle
 func (b Contents) PresentsAsBundle() (bool, error) {
 	imgpkgDirs, err := b.findImgpkgDirs()

--- a/pkg/imgpkg/bundle/contents_test.go
+++ b/pkg/imgpkg/bundle/contents_test.go
@@ -44,7 +44,7 @@ images:
 			t.Fatalf("failed to read tag: %s", err)
 		}
 
-		_, err = subject.Push(imgTag, map[string]string{}, fakeRegistry, util.NewNoopLevelLogger())
+		_, err = subject.Push([]name.Tag{imgTag}, map[string]string{}, fakeRegistry, util.NewNoopLevelLogger())
 		if err != nil {
 			t.Fatalf("not expecting push to fail: %s", err)
 		}
@@ -78,7 +78,7 @@ images:
 			t.Fatalf("failed to read tag: %s", err)
 		}
 
-		_, err = subject.Push(imgTag, map[string]string{}, fakeRegistry, util.NewNoopLevelLogger())
+		_, err = subject.Push([]name.Tag{imgTag}, map[string]string{}, fakeRegistry, util.NewNoopLevelLogger())
 		if err != nil {
 			t.Fatalf("not expecting push to fail: %s", err)
 		}

--- a/pkg/imgpkg/bundle/locations_configs.go
+++ b/pkg/imgpkg/bundle/locations_configs.go
@@ -133,7 +133,7 @@ func (r LocationsConfigs) Save(reg ImagesMetadataWriter, bundleRef name.Digest, 
 
 	r.ui.Tracef("Pushing image\n")
 
-	_, err = plainimage.NewContents([]string{tmpDir}, nil, false).Push(locRef, nil, reg.CloneWithLogger(util.NewNoopProgressBar()), logger)
+	_, err = plainimage.NewContents([]string{tmpDir}, nil, false).Push([]name.Tag{locRef}, nil, reg.CloneWithLogger(util.NewNoopProgressBar()), logger)
 	if err != nil {
 		// Immutable tag errors within registries are not standardized.
 		// Assume word "immutable" would be present in most cases.

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -101,7 +101,6 @@ func (po *PushOptions) Run() error {
 }
 
 func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
-
 	imageURL := ""
 	imageRefs := []string{}
 	uploadRefs := []regname.Tag{}
@@ -119,21 +118,14 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 	// Append the base image_tag to the list of refs to upload
 	uploadRefs = append(uploadRefs, baseRef)
 
-	// TODO(phenixblue): Cleanup when done testing
-	fmt.Printf("\nAdding base ref to list of tags: %s\n", baseRef)
-
 	// Loop through all tags specified by the user and push the related image+tag
 	for _, tag := range po.TagFlags.Tags {
-
 		uploadRef, err := regname.NewTag(baseImageName+":"+tag, regname.WeakValidation)
 		if err != nil {
 			return "", fmt.Errorf("Parsing '%s': %s", tag, err)
 		}
 
 		uploadRefs = append(uploadRefs, uploadRef)
-		// TODO(phenixblue): Cleanup when done testing
-		fmt.Printf("\nAdding non-base ref to list of tags: %s\n", uploadRef)
-
 	}
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
@@ -180,7 +172,6 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 }
 
 func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
-
 	imageURL := ""
 	imageRefs := []string{}
 	uploadRefs := []regname.Tag{}
@@ -212,14 +203,12 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 
 	// Loop through all tags specified by the user and push the related image+tag
 	for _, tag := range po.TagFlags.Tags {
-
 		uploadRef, err := regname.NewTag(baseImageName+":"+tag, regname.WeakValidation)
 		if err != nil {
 			return "", fmt.Errorf("Parsing '%s': %s", tag, err)
 		}
 
 		uploadRefs = append(uploadRefs, uploadRef)
-
 	}
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
@@ -260,13 +249,11 @@ func (po *PushOptions) validateFlags() error {
 }
 
 func (po *PushOptions) stripTag() (string, error) {
-
 	object := ""
 	isBundle := po.BundleFlags.Bundle != ""
 	isImage := po.ImageFlags.Image != ""
 
 	switch {
-
 	case isBundle:
 		object = po.BundleFlags.Bundle
 

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -129,17 +129,9 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
 
-	if len(po.TagFlags.Tags) > 1 {
-		imageURL, err = bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).MultiTagPush(uploadRefs, po.LabelFlags.Labels, registry, logger)
-		if err != nil {
-			return "", err
-		}
-
-	} else {
-		imageURL, err = bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRefs[0], po.LabelFlags.Labels, registry, logger)
-		if err != nil {
-			return "", err
-		}
+	imageURL, err = bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRefs, po.LabelFlags.Labels, registry, logger)
+	if err != nil {
+		return "", err
 	}
 
 	if po.LockOutputFlags.LockFilePath != "" {
@@ -211,16 +203,9 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 
 	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
 
-	if len(po.TagFlags.Tags) > 1 {
-		imageURL, err = plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).MultiTagPush(uploadRefs, po.LabelFlags.Labels, registry, logger)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		imageURL, err = plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRefs[0], po.LabelFlags.Labels, registry, logger)
-		if err != nil {
-			return "", err
-		}
+	imageURL, err = plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRefs, po.LabelFlags.Labels, registry, logger)
+	if err != nil {
+		return "", err
 	}
 
 	if !strings.Contains(strings.Join(imageRefs, ","), imageURL) {

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cppforlife/go-cli-ui/ui"
 	regname "github.com/google/go-containerregistry/pkg/name"
@@ -25,6 +26,7 @@ type PushOptions struct {
 	FileFlags       FileFlags
 	RegistryFlags   RegistryFlags
 	LabelFlags      LabelFlags
+	TagFlags        TagFlags
 }
 
 func NewPushOptions(ui ui.UI) *PushOptions {
@@ -49,6 +51,7 @@ func NewPushCmd(o *PushOptions) *cobra.Command {
 	o.FileFlags.Set(cmd)
 	o.RegistryFlags.Set(cmd)
 	o.LabelFlags.Set(cmd)
+	o.TagFlags.Set(cmd)
 
 	return cmd
 }
@@ -92,52 +95,67 @@ func (po *PushOptions) Run() error {
 		panic("Unreachable code")
 	}
 
-	po.ui.BeginLinef("Pushed '%s'", imageURL)
+	po.ui.BeginLinef("Pushed: \n%s\n", imageURL)
 
 	return nil
 }
 
 func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
-	uploadRef, err := regname.NewTag(po.BundleFlags.Bundle, regname.WeakValidation)
-	if err != nil {
-		return "", fmt.Errorf("Parsing '%s': %s", po.BundleFlags.Bundle, err)
-	}
 
-	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
-	imageURL, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.LabelFlags.Labels, registry, logger)
+	imageRefs := []string{}
+
+	baseBundleName, err := po.stripTag()
 	if err != nil {
 		return "", err
 	}
 
-	if po.LockOutputFlags.LockFilePath != "" {
-		bundleLock := lockconfig.BundleLock{
-			LockVersion: lockconfig.LockVersion{
-				APIVersion: lockconfig.BundleLockAPIVersion,
-				Kind:       lockconfig.BundleLockKind,
-			},
-			Bundle: lockconfig.BundleRef{
-				Image: imageURL,
-				Tag:   uploadRef.TagStr(),
-			},
+	// Loop through all tags specified by the user and push the related bundle+tag
+	for _, tag := range po.TagFlags.Tags {
+		uploadRef, err := regname.NewTag(baseBundleName+":"+tag, regname.WeakValidation)
+		if err != nil {
+			return "", fmt.Errorf("Parsing '%s': %s", tag, err)
 		}
 
-		err := bundleLock.WriteToPath(po.LockOutputFlags.LockFilePath)
+		logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
+		imageURL, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.LabelFlags.Labels, registry, logger)
 		if err != nil {
 			return "", err
 		}
+
+		if po.LockOutputFlags.LockFilePath != "" {
+			bundleLock := lockconfig.BundleLock{
+				LockVersion: lockconfig.LockVersion{
+					APIVersion: lockconfig.BundleLockAPIVersion,
+					Kind:       lockconfig.BundleLockKind,
+				},
+				Bundle: lockconfig.BundleRef{
+					Image: imageURL,
+					Tag:   uploadRef.TagStr(),
+				},
+			}
+
+			err := bundleLock.WriteToPath(po.LockOutputFlags.LockFilePath)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		if !strings.Contains(strings.Join(imageRefs, ","), imageURL) {
+			imageRefs = append(imageRefs, imageURL)
+		}
 	}
 
-	return imageURL, nil
+	po.ui.BeginLinef("Tags: %s\n", strings.Join(po.TagFlags.Tags, ", "))
+
+	return strings.Join(imageRefs, "\n"), nil
 }
 
 func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
+
+	imageRefs := []string{}
+
 	if po.LockOutputFlags.LockFilePath != "" {
 		return "", fmt.Errorf("Lock output is not compatible with image, use bundle for lock output")
-	}
-
-	uploadRef, err := regname.NewTag(po.ImageFlags.Image, regname.WeakValidation)
-	if err != nil {
-		return "", fmt.Errorf("Parsing '%s': %s", po.ImageFlags.Image, err)
 	}
 
 	isBundle, err := bundle.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).PresentsAsBundle()
@@ -148,8 +166,33 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 		return "", fmt.Errorf("Images cannot be pushed with '.imgpkg' directories, consider using --bundle (-b) option")
 	}
 
-	logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
-	return plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.LabelFlags.Labels, registry, logger)
+	baseImageName, err := po.stripTag()
+	if err != nil {
+		return "", err
+	}
+
+	// Loop through all tags specified by the user and push the related image+tag
+	for _, tag := range po.TagFlags.Tags {
+
+		uploadRef, err := regname.NewTag(baseImageName+":"+tag, regname.WeakValidation)
+		if err != nil {
+			return "", fmt.Errorf("Parsing '%s': %s", tag, err)
+		}
+
+		logger := util.NewUILevelLogger(util.LogWarn, util.NewLogger(po.ui))
+		imageURL, err := plainimage.NewContents(po.FileFlags.Files, po.FileFlags.ExcludedFilePaths, po.FileFlags.PreservePermissions).Push(uploadRef, po.LabelFlags.Labels, registry, logger)
+		if err != nil {
+			return "", err
+		}
+
+		if !strings.Contains(strings.Join(imageRefs, ","), imageURL) {
+			imageRefs = append(imageRefs, imageURL)
+		}
+	}
+
+	po.ui.BeginLinef("Tags: %s\n", strings.Join(po.TagFlags.Tags, ", "))
+
+	return strings.Join(imageRefs, "\n"), nil
 }
 
 // validateFlags checks if the provided flags are valid
@@ -164,4 +207,53 @@ func (po *PushOptions) validateFlags() error {
 
 	return nil
 
+}
+
+func (po *PushOptions) stripTag() (string, error) {
+
+	object := ""
+	isBundle := po.BundleFlags.Bundle != ""
+	isImage := po.ImageFlags.Image != ""
+
+	switch {
+
+	case isBundle:
+		object = po.BundleFlags.Bundle
+
+	case isImage:
+		object = po.ImageFlags.Image
+
+	default:
+		panic("Unreachable code")
+	}
+
+	objectRef, err := regname.NewTag(object, regname.WeakValidation)
+	if err != nil {
+		fmt.Println("FAILING BEFORE TAG STRIP")
+		fmt.Printf("TEST - BUNDLE NAME: %s\n", po.BundleFlags.Bundle)
+		fmt.Printf("TEST - REGISTRY: %s\n", objectRef.RegistryStr())
+		fmt.Printf("TEST - REPOSITORY: %s\n", objectRef.RepositoryStr())
+		fmt.Printf("TEST - NAME: %s\n", objectRef.Name())
+		fmt.Printf("TEST - TAG: %s\n", objectRef.TagStr())
+		return "", fmt.Errorf("Parsing '%s': %s", object, err)
+	}
+
+	embeddedTag := objectRef.TagStr()
+
+	fmt.Printf("TEST - REGISTRY: %s\n", objectRef.RegistryStr())
+	fmt.Printf("TEST - REPOSITORY: %s\n", objectRef.RepositoryStr())
+	fmt.Printf("TEST - NAME: %s\n", objectRef.Name())
+	fmt.Printf("TEST - TAG: %s\n", objectRef.TagStr())
+
+	if embeddedTag != "" {
+		po.TagFlags.Tags = append(po.TagFlags.Tags, embeddedTag)
+	}
+
+	baseObjectName := strings.TrimSuffix(objectRef.Name(), ":"+objectRef.TagStr())
+
+	if baseObjectName == "" {
+		return "", fmt.Errorf("'%s' is not a valid image reference", object)
+	}
+
+	return baseObjectName, nil
 }

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -248,6 +248,7 @@ func (po *PushOptions) validateFlags() error {
 
 }
 
+// stripTag removes the tag from the provided image or bundle reference
 func (po *PushOptions) stripTag() (string, error) {
 	object := ""
 	isBundle := po.BundleFlags.Bundle != ""

--- a/pkg/imgpkg/cmd/push.go
+++ b/pkg/imgpkg/cmd/push.go
@@ -103,7 +103,6 @@ func (po *PushOptions) Run() error {
 func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 	imageURL := ""
 	imageRefs := []string{}
-	uploadRefs := []regname.Tag{}
 
 	baseImageName, err := po.stripTag()
 	if err != nil {
@@ -116,7 +115,7 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 	}
 
 	// Append the base image_tag to the list of refs to upload
-	uploadRefs = append(uploadRefs, baseRef)
+	uploadRefs := []regname.Tag{baseRef}
 
 	// Loop through all tags specified by the user and push the related image+tag
 	for _, tag := range po.TagFlags.Tags {
@@ -174,7 +173,6 @@ func (po *PushOptions) pushBundle(registry registry.Registry) (string, error) {
 func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 	imageURL := ""
 	imageRefs := []string{}
-	uploadRefs := []regname.Tag{}
 
 	if po.LockOutputFlags.LockFilePath != "" {
 		return "", fmt.Errorf("Lock output is not compatible with image, use bundle for lock output")
@@ -199,7 +197,7 @@ func (po *PushOptions) pushImage(registry registry.Registry) (string, error) {
 	}
 
 	// Append the base image_tag to the list of refs to upload
-	uploadRefs = append(uploadRefs, baseRef)
+	uploadRefs := []regname.Tag{baseRef}
 
 	// Loop through all tags specified by the user and push the related image+tag
 	for _, tag := range po.TagFlags.Tags {

--- a/pkg/imgpkg/cmd/push_test.go
+++ b/pkg/imgpkg/cmd/push_test.go
@@ -326,6 +326,110 @@ func TestLabels(t *testing.T) {
 	}
 }
 
+func TestTags(t *testing.T) {
+	testCases := []struct {
+		name          string
+		opType        string
+		expectedError string
+		expectedTags  []string
+		tagInput      string
+		inlineTag     string
+	}{
+		{
+			name:          "bundle with one inline tag",
+			opType:        "bundle",
+			expectedError: "",
+			tagInput:      "",
+			expectedTags:  []string{"v1.0.1"},
+			inlineTag:     "v1.0.1",
+		},
+		{
+			name:          "bundle with one tag via flag",
+			opType:        "bundle",
+			expectedError: "",
+			tagInput:      "v1.0.1",
+			expectedTags:  []string{"v1.0.1", "latest"},
+			inlineTag:     "",
+		},
+		{
+			name:          "bundle with inline tag and tag via flag",
+			opType:        "bundle",
+			expectedError: "",
+			tagInput:      "v1.0.2",
+			expectedTags:  []string{"v1.0.1", "v1.0.2"},
+			inlineTag:     "v1.0.1",
+		},
+		{
+			name:          "bundle with multiple tags via flag",
+			opType:        "bundle",
+			expectedError: "",
+			tagInput:      "v1.0.1,v1.0.2",
+			expectedTags:  []string{"v1.0.1", "v1.0.2", "latest"},
+			inlineTag:     "",
+		},
+		{
+			name:          "image with one inline tag",
+			opType:        "image",
+			expectedError: "",
+			tagInput:      "",
+			expectedTags:  []string{"v1.0.1"},
+			inlineTag:     "v1.0.1",
+		},
+		{
+			name:          "image with one tag via flag",
+			opType:        "image",
+			expectedError: "",
+			tagInput:      "v1.0.1",
+			expectedTags:  []string{"v1.0.1", "latest"},
+			inlineTag:     "",
+		},
+	}
+
+	for _, tc := range testCases {
+		f := func(t *testing.T) {
+			env := helpers.BuildEnv(t)
+			targetImage := env.Image
+			imgpkg := helpers.Imgpkg{T: t, ImgpkgPath: env.ImgpkgPath}
+			defer env.Cleanup()
+
+			opTypeFlag := "-b"
+			pushDir := env.BundleFactory.CreateBundleDir(helpers.BundleYAML, helpers.ImagesYAML)
+
+			if tc.opType == "image" {
+				opTypeFlag = "-i"
+				pushDir = env.Assets.CreateAndCopySimpleApp("image-to-push")
+			}
+
+			if tc.inlineTag != "" {
+				targetImage = env.Image + ":" + tc.inlineTag
+			}
+
+			if tc.tagInput == "" {
+				imgpkg.Run([]string{"push", opTypeFlag, targetImage, "-f", pushDir})
+			} else {
+				imgpkg.Run([]string{"push", opTypeFlag, targetImage, "--additional-tags", tc.tagInput, "-f", pushDir})
+			}
+
+			// Loop through expected tags and validate they exist on the image
+			for _, tag := range tc.expectedTags {
+				ref, _ := name.NewTag(env.Image+":"+tag, name.WeakValidation)
+				image, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+				require.NoError(t, err)
+
+				tagList := imgpkg.Run([]string{"tag", "ls", "-i", env.Image + ":" + tag})
+
+				_, err = image.ConfigFile()
+				require.NoError(t, err)
+
+				require.Contains(t, tagList, tag, "Expected tags provided via flags to match tags discovered for image")
+
+			}
+		}
+
+		t.Run(tc.name, f)
+	}
+}
+
 func Cleanup(dirs ...string) {
 	for _, dir := range dirs {
 		os.RemoveAll(dir)

--- a/pkg/imgpkg/cmd/push_test.go
+++ b/pkg/imgpkg/cmd/push_test.go
@@ -355,8 +355,8 @@ func TestTags(t *testing.T) {
 			name:          "bundle with inline tag and tag via flag",
 			opType:        "bundle",
 			expectedError: "",
-			tagInput:      "v1.0.2",
-			expectedTags:  []string{"v1.0.1", "v1.0.2"},
+			tagInput:      "v1.2.0-alpha,latest",
+			expectedTags:  []string{"v1.0.1", "v1.2.0-alpha", "latest"},
 			inlineTag:     "v1.0.1",
 		},
 		{
@@ -382,6 +382,14 @@ func TestTags(t *testing.T) {
 			tagInput:      "v1.0.1",
 			expectedTags:  []string{"v1.0.1", "latest"},
 			inlineTag:     "",
+		},
+		{
+			name:          "image with inline tag and tags via flag",
+			opType:        "image",
+			expectedError: "",
+			tagInput:      "latest,stable",
+			expectedTags:  []string{"v1.0.1", "latest"},
+			inlineTag:     "v1.0.1",
 		},
 	}
 

--- a/pkg/imgpkg/cmd/tag_flags.go
+++ b/pkg/imgpkg/cmd/tag_flags.go
@@ -1,0 +1,18 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// TagFlags is a struct that holds the additional tags for an OCI artifact
+type TagFlags struct {
+	Tags []string
+}
+
+// Set sets additional tags for an OCI artifact
+func (t *TagFlags) Set(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&t.Tags, "additional-tags", []string{}, "Set additional tags on image")
+}

--- a/pkg/imgpkg/lockconfig/bundle_lock.go
+++ b/pkg/imgpkg/lockconfig/bundle_lock.go
@@ -22,8 +22,9 @@ type BundleLock struct {
 }
 
 type BundleRef struct {
-	Image string `json:"image,omitempty"` // This generated yaml, but due to lib we need to use `json`
-	Tag   string `json:"tag,omitempty"`   // This generated yaml, but due to lib we need to use `json`
+	Image     string `json:"image,omitempty"` // This generated yaml, but due to lib we need to use `json`
+	Tag       string `json:"tag,omitempty"`   // This generated yaml, but due to lib we need to use `json`
+	OtherTags string `json:"otherTags,omitempty"`
 }
 
 func NewBundleLockFromPath(path string) (BundleLock, error) {


### PR DESCRIPTION
These changes add the ability to specify additional OCI tags to be pushed when using `imgpkg`.

It adds the `--additional-tags` flag to `imgpkg push` command and allows the user to specify a comma separated list of additional tags, or the flag can be reused multiple times. This flag functions for both images and bundles.


## Comma Separated List

```shell
$ ./imgpkg push -i jmsearcy/test-imgpkg-image -f ./pkg/imgpkg/cmd/test_assets/image_with_config --additional-tags 1.0.1,1.0.2

TEST - REGISTRY: index.docker.io
TEST - REPOSITORY: jmsearcy/test-imgpkg-image
TEST - NAME: index.docker.io/jmsearcy/test-imgpkg-image:latest
TEST - TAG: latest
dir: .
file: config.yml
dir: .
file: config.yml
dir: .
file: config.yml
Tags: 1.0.1, 1.0.2, latest
Pushed:
index.docker.io/jmsearcy/test-imgpkg-image@sha256:7b77aebdd49c9d3babf251703ce8cc660cf0fd040aa5d29f262d2084e2d59e8a

Succeeded
```

## Multiple flags

```shell
$ ./imgpkg push -i jmsearcy/test-imgpkg-image -f ./pkg/imgpkg/cmd/test_assets/image_with_config --additional-tags 1.0.1 --additional-tags 1.0.2

TEST - REGISTRY: index.docker.io
TEST - REPOSITORY: jmsearcy/test-imgpkg-image
TEST - NAME: index.docker.io/jmsearcy/test-imgpkg-image:latest
TEST - TAG: latest
dir: .
file: config.yml
dir: .
file: config.yml
dir: .
file: config.yml
Tags: 1.0.1, 1.0.2, latest
Pushed:
index.docker.io/jmsearcy/test-imgpkg-image@sha256:7b77aebdd49c9d3babf251703ce8cc660cf0fd040aa5d29f262d2084e2d59e8a

Succeeded
```

Fixes #355