### PR TITLE
Copying a bundle with the image-is-bundle-check being false now directs user to use correct flag.

### DIFF
--- a/pkg/imgpkg/cmd/pull.go
+++ b/pkg/imgpkg/cmd/pull.go
@@ -91,17 +91,24 @@ func (po *PullOptions) Run() error {
 	}
 
 	if errors.Is(err, &v1.ErrIsBundle{}) {
-		if len(po.ImageFlags.Image) == 0 {
+		if pullOpts.IsBundle {
 			if po.ImageIsBundleCheck {
 				return fmt.Errorf("Expected bundle flag when pulling a bundle (hint: Use -b instead of -i for bundles)")
+			} else {
+				return fmt.Errorf("Expected image flag when wanting to pull a bundle as OCI image (hint: Use -i instead of -b)")
 			}
 		} else {
 			return fmt.Errorf("Expected bundle flag when pulling a bundle (hint: Use -b instead of -i for bundles)")
 		}
-	} else if len(po.ImageFlags.Image) == 0 && errors.Is(err, &v1.ErrIsNotBundle{}) {
-		return fmt.Errorf("Expected bundle image but found plain image (hint: Did you use -i instead of -b?)")
+	} else if errors.Is(err, &v1.ErrIsNotBundle{}) {
+		if pullOpts.IsBundle {
+			return fmt.Errorf("Expected bundle image but found plain image (hint: Did you use -i instead of -b?)")
+		} else {
+			if po.ImageIsBundleCheck {
+				return fmt.Errorf("Expected correct flag with bundle image (hint: Use --image-is-bundle-check=false instead of --image-is-bundle-check=true for images)")
+			}
+		}
 	}
-
 	return err
 }
 

--- a/pkg/imgpkg/v1/pull.go
+++ b/pkg/imgpkg/v1/pull.go
@@ -102,7 +102,10 @@ func PullWithRegistry(imageRef string, outputPath string, pullOptions PullOpts, 
 	}
 
 	switch {
-	case isBundle && pullOptions.AsImage: // Trying to pull the OCI Image of a Bundle
+	case isBundle && pullOptions.AsImage && pullOptions.IsBundle: // Trying to pull a Bundle as an OCI Image with flag -b
+		return PullStatus{}, &ErrIsBundle{}
+
+	case isBundle && pullOptions.AsImage && !pullOptions.IsBundle: // Trying to pull the OCI Image of a Bundle with flag i
 		st, err := pullImage(imageRef, outputPath, pullOptions, reg)
 		if err != nil {
 			return PullStatus{}, err
@@ -116,7 +119,10 @@ func PullWithRegistry(imageRef string, outputPath string, pullOptions PullOpts, 
 	case !isBundle && pullOptions.IsBundle: // Trying to pull an Image as a Bundle
 		return PullStatus{}, &ErrIsNotBundle{}
 
-	case !isBundle && !pullOptions.IsBundle: // Trying to pull an OCI Image
+	case !isBundle && !pullOptions.IsBundle && !pullOptions.AsImage: // Trying to pull an OCI Image
+		return PullStatus{}, &ErrIsBundle{}
+
+	case !isBundle && !pullOptions.IsBundle && pullOptions.AsImage: // Trying to pull an OCI Image
 		return pullImage(imageRef, outputPath, pullOptions, reg)
 
 	case isBundle && !pullOptions.IsBundle: // Trying to pull a Bundle as if it where an OCI Image


### PR DESCRIPTION
This solves #544 and #559.

## Initial Issue 
The command 
```
imgpkg pull -b index.docker.io/<user>/<repo>:<tag> --image-is-bundle-check=false -o <location>
```
successfully runs and will pull it as an image, which is a bit weird because we are trying to pull a bundle using the bundle flag.

## Initial Fix
Now running the command throws this error 
```
imgpkg: Error: Expected image flag when wanting to pull a bundle as OCI image (hint: Use -i instead of -b)
```

## Analysis
<img width="1112" alt="Screenshot 2023-08-11 at 2 08 10 PM" src="https://github.com/carvel-dev/imgpkg/assets/93992470/bd72e1ff-f550-43b3-b1c0-47400858dc05">

As seen from the picture , the case when we pass a image link along with the -I flag and the —image-is-bundle-check flag=true also gets passed by and the image is pulled.

## What steps did I take ? 
- Removed some redundant variable checking
- Added checks for both the cases and printed error for the user.
