### PR TITLE
Error when --image-is-bundle-check flag is set to false while using -b flag 

### DIFF
--- a/pkg/imgpkg/cmd/pull.go
+++ b/pkg/imgpkg/cmd/pull.go
@@ -130,5 +130,9 @@ func (po *PullOptions) validate() error {
 	if po.BundleRecursiveFlags.Recursive && len(po.ImageFlags.Image) > 0 {
 		return fmt.Errorf("Cannot use --recursive (-r) flag when pulling a bundle")
 	}
+
+	if !po.ImageIsBundleCheck && len(po.BundleFlags.Bundle) != 0 {
+		return fmt.Errorf("Cannot set --image-is-bundle-check while using -b flag")
+	}
 	return nil
 }

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -262,6 +262,19 @@ func TestPullImageOfBundle(t *testing.T) {
 		assert.Contains(t, out.String(), "Expected bundle flag when pulling a bundle (hint: Use -b instead of -i for bundles)")
 	})
 
+	t.Run("when --image-is-bundle-check=false is provided while using the -b flag it fails", func(t *testing.T) {
+		pullDir := env.Assets.CreateTempFolder("pull-bundle-image")
+		out := bytes.NewBufferString("")
+		_, err := imgpkg.RunWithOpts([]string{"pull", "--tty", "-b", randomBundle.RefDigest, "-o", pullDir, "--image-is-bundle-check=false"}, helpers.RunOpts{
+			AllowError:   true,
+			StderrWriter: out,
+			StdoutWriter: out,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, out.String(), "Cannot set --image-is-bundle-check while using -b flag")
+	})
+
 	t.Run("when --image-is-bundle-check=false is provided downloads the OCI Image of the bundle", func(t *testing.T) {
 		pullDir := env.Assets.CreateTempFolder("pull-bundle-image")
 		imgpkg.RunWithOpts([]string{"pull", "--tty", "-i", randomBundle.RefDigest, "-o", pullDir, "--image-is-bundle-check=false"}, helpers.RunOpts{})


### PR DESCRIPTION
This solves #544 

## Issue 
The command 
```
imgpkg pull -b index.docker.io/<user>/<repo>:<tag> --image-is-bundle-check=false -o <location>
```
successfully runs and will pull it as an image, which is a bit weird because we are trying to pull a bundle using the bundle flag.

## Fix
Now running the command throws this error 
```
imgpkg: Error: Setting --image-is-bundle-check flag to false is not allowed when using -b flag.
```