### PR TITLE
Updated test to build binary locally based on variable value

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -2,7 +2,11 @@
 
 set -e -x -u
 
-./hack/build.sh
+# By default it will generate binary of imgpkg to run test. 
+# export BUILD_BINARY=false to skip binary generation
+if [ ${BUILD_BINARY:-true} == true ]; then
+    ./hack/build.sh
+fi
 
 export IMGPKG_BINARY="$PWD/imgpkg${IMGPKG_BINARY_EXT-}"
 


### PR DESCRIPTION
Updated test to build binary locally based on variable value. Default it is set to true. If you do not want to build binary through test-all.sh run: `export BUILD_LOCAL=false`