### PR TITLE
Updated describe command to show layer's digest of each image

### DIFF
--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -140,7 +140,7 @@ func (p bundleTextPrinter) printerRec(description v1.Description, originalLogger
 		indentLogger.Logf("  Origin: %s\n", b.Origin)
 		indentLogger.Logf("  Layers:\n")
 		for _, d := range b.Layers {
-			indentLogger.Logf("    - Digest: %s\n", d)
+			indentLogger.Logf("    - Digest: %s\n", d.Digest)
 		}
 		annotations := b.Annotations
 
@@ -166,7 +166,7 @@ func (p bundleTextPrinter) printerRec(description v1.Description, originalLogger
 		}
 		indentLogger.Logf("  Layers:\n")
 		for _, d := range image.Layers {
-			indentLogger.Logf("    - Digest: %s\n", d)
+			indentLogger.Logf("    - Digest: %s\n", d.Digest)
 		}
 		annotations := image.Annotations
 		p.printAnnotations(annotations, util.NewIndentedLogger(indentLogger))

--- a/pkg/imgpkg/cmd/describe.go
+++ b/pkg/imgpkg/cmd/describe.go
@@ -138,6 +138,10 @@ func (p bundleTextPrinter) printerRec(description v1.Description, originalLogger
 		indentLogger.Logf("- Image: %s\n", b.Image)
 		indentLogger.Logf("  Type: Bundle\n")
 		indentLogger.Logf("  Origin: %s\n", b.Origin)
+		indentLogger.Logf("  Layers:\n")
+		for _, d := range b.Layers {
+			indentLogger.Logf("    - Digest: %s\n", d)
+		}
 		annotations := b.Annotations
 
 		p.printAnnotations(annotations, util.NewIndentedLogger(indentLogger))
@@ -159,6 +163,10 @@ func (p bundleTextPrinter) printerRec(description v1.Description, originalLogger
 		indentLogger.Logf("  Type: %s\n", image.ImageType)
 		if image.ImageType == bundle.ContentImage {
 			indentLogger.Logf("  Origin: %s\n", image.Origin)
+		}
+		indentLogger.Logf("  Layers:\n")
+		for _, d := range image.Layers {
+			indentLogger.Logf("    - Digest: %s\n", d)
 		}
 		annotations := image.Annotations
 		p.printAnnotations(annotations, util.NewIndentedLogger(indentLogger))

--- a/test/e2e/describe_test.go
+++ b/test/e2e/describe_test.go
@@ -67,11 +67,13 @@ images:
 					"--bundle", fmt.Sprintf("%s%s", env.RelocationRepo, bundleDigest),
 				},
 			)
-
+			fmt.Printf("\n\nOutput: %s\n\n", stdout)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Image
     Origin: %s%s
+	Layers:
+	- Digest: "sha256:a37f35f3e418ea6c1b339df0fc89c8d3155d937740445906ba71466996fac625"
     Annotations:
       some.annotation: some value
       some.other.annotation: some other value
@@ -80,19 +82,27 @@ images:
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Signature
+	Layers:
+	  - Digest: "sha256:4197c5ac7fb0ba1e597a2377a1b58332d10f6de53dce9c89fd96a3f37034f88b"
     Annotations:
       tag: %s
 `, env.RelocationRepo, imgSigDigest, imgSigTag))
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Signature
+	Layers:
+	  - Digest: "sha256:28014a7e4bef0b7c3f1da47d095f8bb131f474bd5fc96caa4d6125818220b00e"
     Annotations:
       tag: %s
 `, env.RelocationRepo, bundleSigDigest, bundleSigTag))
 
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
-    Type: Internal`, env.RelocationRepo, locationsImgDigest))
+    Type: Internal
+	Layers:
+	  - 
+	  Digest: "sha256:5d43e9fc8f1ad1b339b5f37bb050b150640ad2c1594345178f1fb38656583a94"
+`, env.RelocationRepo, locationsImgDigest))
 		})
 	})
 

--- a/test/e2e/describe_test.go
+++ b/test/e2e/describe_test.go
@@ -68,7 +68,7 @@ images:
 				},
 			)
 
-			digestSha := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + imageDigest)
+			digestSha := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + imageDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Image
@@ -80,7 +80,7 @@ images:
       some.other.annotation: some other value
 `, env.RelocationRepo, imageDigest, env.Image, imageDigest, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + imgSigDigest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + imgSigDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Signature
@@ -90,7 +90,7 @@ images:
       tag: %s
 `, env.RelocationRepo, imgSigDigest, digestSha[0], imgSigTag))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + bundleSigDigest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + bundleSigDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Signature
@@ -100,7 +100,7 @@ images:
       tag: %s
 `, env.RelocationRepo, bundleSigDigest, digestSha[0], bundleSigTag))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsImgDigest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsImgDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Internal
@@ -179,7 +179,7 @@ images:
 			locationsNestedBundleImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(nestedBundleDigest[1:], ":", "-")))
 			locationsOuterBundleImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(outerBundleDigest[1:], ":", "-")))
 
-			digestSha := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + nestedBundleDigest)
+			digestSha := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + nestedBundleDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Bundle
@@ -190,7 +190,7 @@ images:
       what is this: this is the nested bundle
 `, env.RelocationRepo, nestedBundleDigest, nestedBundle, nestedBundleDigest, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + img1Digest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s%s
       Type: Image
@@ -199,7 +199,7 @@ images:
         - Digest: %s
 `, env.RelocationRepo, img1Digest, img1DigestRef, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img2Digest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + img2Digest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s%s
       Type: Image
@@ -208,7 +208,7 @@ images:
         - Digest: %s
 `, env.RelocationRepo, img2Digest, img2DigestRef, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsNestedBundleImgDigest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsNestedBundleImgDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s@%s
       Type: Internal
@@ -216,7 +216,7 @@ images:
         - Digest: %s
 `, env.RelocationRepo, locationsNestedBundleImgDigest, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + img1Digest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Image
@@ -227,7 +227,7 @@ images:
       what is this: this is just an image
 `, env.RelocationRepo, img1Digest, img1DigestRef, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsOuterBundleImgDigest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsOuterBundleImgDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Internal
@@ -299,7 +299,7 @@ images:
 				},
 			)
 
-			digestSha := env.ImageFactory.GetImageLayerDigest(nestedBundle + nestedBundleDigest)
+			digestSha := env.ImageFactory.GetImageLayersDigest(nestedBundle + nestedBundleDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Bundle
@@ -308,7 +308,7 @@ images:
       - Digest: %s
 `, nestedBundle, nestedBundleDigest, nestedBundle, nestedBundleDigest, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(img1DigestRef)
+			digestSha = env.ImageFactory.GetImageLayersDigest(img1DigestRef)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s
       Type: Image
@@ -317,7 +317,7 @@ images:
         - Digest: %s
 `, img1DigestRef, img1DigestRef, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(img2DigestRef)
+			digestSha = env.ImageFactory.GetImageLayersDigest(img2DigestRef)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s
       Type: Image
@@ -326,7 +326,7 @@ images:
         - Digest: %s
 `, img2DigestRef, img2DigestRef, digestSha[0]))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(imgRef.Context().Name() + "-img2" + "@" + img2SigDigest)
+			digestSha = env.ImageFactory.GetImageLayersDigest(imgRef.Context().Name() + "-img2" + "@" + img2SigDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s@%s
       Type: Signature
@@ -336,7 +336,7 @@ images:
         tag: %s
 `, imgRef.Context().Name()+"-img2", img2SigDigest, digestSha[0], img2SigTag))
 
-			digestSha = env.ImageFactory.GetImageLayerDigest(img1DigestRef)
+			digestSha = env.ImageFactory.GetImageLayersDigest(img1DigestRef)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s
       Type: Image
@@ -403,11 +403,11 @@ images:
 
 			stdoutLines := strings.Split(stdout, "\n")
 			stdout = strings.Join(stdoutLines[:len(stdoutLines)-1], "\n")
-			digestSha1 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + imageDigest)
-			digestSha2 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + bundleSigDigest)
-			digestSha3 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + imgSigDigest)
-			digestSha4 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsImgDigest)
-			digestSha5 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + bundleDigest)
+			digestSha1 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + imageDigest)
+			digestSha2 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + bundleSigDigest)
+			digestSha3 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + imgSigDigest)
+			digestSha4 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsImgDigest)
+			digestSha5 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + bundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`sha: %s
 content:
   images:
@@ -519,11 +519,11 @@ images:
 				},
 			)
 			locationsImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(bundleDigest[1:], ":", "-")))
-			digestSha1 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + imageDigest)
-			digestSha2 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + bundleSigDigest)
-			digestSha3 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + imgSigDigest)
-			digestSha4 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsImgDigest)
-			digestSha5 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + bundleDigest)
+			digestSha1 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + imageDigest)
+			digestSha2 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + bundleSigDigest)
+			digestSha3 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + imgSigDigest)
+			digestSha4 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsImgDigest)
+			digestSha5 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + bundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`content:
   images:
     "%s":
@@ -653,13 +653,13 @@ images:
 			locationsOuterBundleImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(outerBundleDigest[1:], ":", "-")))
 			stdoutLines := strings.Split(stdout, "\n")
 			stdout = strings.Join(stdoutLines[:len(stdoutLines)-1], "\n")
-			digestSha1 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
-			digestSha2 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img2Digest)
-			digestSha3 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsNestedBundleImgDigest)
-			digestSha4 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + nestedBundleDigest)
-			digestSha5 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
-			digestSha6 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsOuterBundleImgDigest)
-			digestSha7 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + outerBundleDigest)
+			digestSha1 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + img1Digest)
+			digestSha2 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + img2Digest)
+			digestSha3 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsNestedBundleImgDigest)
+			digestSha4 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + nestedBundleDigest)
+			digestSha5 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + img1Digest)
+			digestSha6 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + "@" + locationsOuterBundleImgDigest)
+			digestSha7 := env.ImageFactory.GetImageLayersDigest(env.RelocationRepo + outerBundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`sha: %s
 content:
   bundles:
@@ -794,12 +794,12 @@ images:
 
 			stdoutLines := strings.Split(stdout, "\n")
 			stdout = strings.Join(stdoutLines[:len(stdoutLines)-1], "\n")
-			digestSha1 := env.ImageFactory.GetImageLayerDigest(img1DigestRef)
-			digestSha2 := env.ImageFactory.GetImageLayerDigest(img2DigestRef)
-			digestSha3 := env.ImageFactory.GetImageLayerDigest(imgRef.Context().Name() + "-img2" + "@" + img2SigDigest)
-			digestSha4 := env.ImageFactory.GetImageLayerDigest(nestedBundle + nestedBundleDigest)
-			digestSha5 := env.ImageFactory.GetImageLayerDigest(img1DigestRef)
-			digestSha6 := env.ImageFactory.GetImageLayerDigest(outerBundle + outerBundleDigest)
+			digestSha1 := env.ImageFactory.GetImageLayersDigest(img1DigestRef)
+			digestSha2 := env.ImageFactory.GetImageLayersDigest(img2DigestRef)
+			digestSha3 := env.ImageFactory.GetImageLayersDigest(imgRef.Context().Name() + "-img2" + "@" + img2SigDigest)
+			digestSha4 := env.ImageFactory.GetImageLayersDigest(nestedBundle + nestedBundleDigest)
+			digestSha5 := env.ImageFactory.GetImageLayersDigest(img1DigestRef)
+			digestSha6 := env.ImageFactory.GetImageLayersDigest(outerBundle + outerBundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`sha: %s
 content:
   bundles:

--- a/test/e2e/describe_test.go
+++ b/test/e2e/describe_test.go
@@ -67,42 +67,46 @@ images:
 					"--bundle", fmt.Sprintf("%s%s", env.RelocationRepo, bundleDigest),
 				},
 			)
-			fmt.Printf("\n\nOutput: %s\n\n", stdout)
+
+			digestSha := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + imageDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Image
     Origin: %s%s
-	Layers:
-	- Digest: "sha256:a37f35f3e418ea6c1b339df0fc89c8d3155d937740445906ba71466996fac625"
+    Layers:
+      - Digest: %s
     Annotations:
       some.annotation: some value
       some.other.annotation: some other value
-`, env.RelocationRepo, imageDigest, env.Image, imageDigest))
+`, env.RelocationRepo, imageDigest, env.Image, imageDigest, digestSha[0]))
 
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + imgSigDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Signature
-	Layers:
-	  - Digest: "sha256:4197c5ac7fb0ba1e597a2377a1b58332d10f6de53dce9c89fd96a3f37034f88b"
+    Layers:
+      - Digest: %s
     Annotations:
       tag: %s
-`, env.RelocationRepo, imgSigDigest, imgSigTag))
+`, env.RelocationRepo, imgSigDigest, digestSha[0], imgSigTag))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + bundleSigDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Signature
-	Layers:
-	  - Digest: "sha256:28014a7e4bef0b7c3f1da47d095f8bb131f474bd5fc96caa4d6125818220b00e"
+    Layers:
+      - Digest: %s
     Annotations:
       tag: %s
-`, env.RelocationRepo, bundleSigDigest, bundleSigTag))
+`, env.RelocationRepo, bundleSigDigest, digestSha[0], bundleSigTag))
 
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsImgDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Internal
-	Layers:
-	  - 
-	  Digest: "sha256:5d43e9fc8f1ad1b339b5f37bb050b150640ad2c1594345178f1fb38656583a94"
-`, env.RelocationRepo, locationsImgDigest))
+    Layers:
+      - Digest: %s
+`, env.RelocationRepo, locationsImgDigest, digestSha[0]))
 		})
 	})
 
@@ -175,39 +179,61 @@ images:
 			locationsNestedBundleImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(nestedBundleDigest[1:], ":", "-")))
 			locationsOuterBundleImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(outerBundleDigest[1:], ":", "-")))
 
+			digestSha := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + nestedBundleDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Bundle
     Origin: %s%s
+    Layers:
+      - Digest: %s
     Annotations:
       what is this: this is the nested bundle
-`, env.RelocationRepo, nestedBundleDigest, nestedBundle, nestedBundleDigest))
+`, env.RelocationRepo, nestedBundleDigest, nestedBundle, nestedBundleDigest, digestSha[0]))
 
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s%s
       Type: Image
       Origin: %s
-`, env.RelocationRepo, img1Digest, img1DigestRef))
+      Layers:
+        - Digest: %s
+`, env.RelocationRepo, img1Digest, img1DigestRef, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img2Digest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s%s
       Type: Image
       Origin: %s
-`, env.RelocationRepo, img2Digest, img2DigestRef))
+      Layers:
+        - Digest: %s
+`, env.RelocationRepo, img2Digest, img2DigestRef, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsNestedBundleImgDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s@%s
       Type: Internal
-`, env.RelocationRepo, locationsNestedBundleImgDigest))
+      Layers:
+        - Digest: %s
+`, env.RelocationRepo, locationsNestedBundleImgDigest, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Image
     Origin: %s
+    Layers:
+      - Digest: %s
     Annotations:
       what is this: this is just an image
-`, env.RelocationRepo, img1Digest, img1DigestRef))
+`, env.RelocationRepo, img1Digest, img1DigestRef, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsOuterBundleImgDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s@%s
     Type: Internal
-`, env.RelocationRepo, locationsOuterBundleImgDigest))
+    Layers:
+      - Digest: %s
+`, env.RelocationRepo, locationsOuterBundleImgDigest, digestSha[0]))
 		})
 	})
 
@@ -273,33 +299,51 @@ images:
 				},
 			)
 
+			digestSha := env.ImageFactory.GetImageLayerDigest(nestedBundle + nestedBundleDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`  - Image: %s%s
     Type: Bundle
     Origin: %s%s
-`, nestedBundle, nestedBundleDigest, nestedBundle, nestedBundleDigest))
+    Layers:
+      - Digest: %s
+`, nestedBundle, nestedBundleDigest, nestedBundle, nestedBundleDigest, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(img1DigestRef)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s
       Type: Image
       Origin: %s
-`, img1DigestRef, img1DigestRef))
+      Layers:
+        - Digest: %s
+`, img1DigestRef, img1DigestRef, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(img2DigestRef)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s
       Type: Image
       Origin: %s
-`, img2DigestRef, img2DigestRef))
+      Layers:
+        - Digest: %s
+`, img2DigestRef, img2DigestRef, digestSha[0]))
+
+			digestSha = env.ImageFactory.GetImageLayerDigest(imgRef.Context().Name() + "-img2" + "@" + img2SigDigest)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s@%s
       Type: Signature
+      Layers:
+        - Digest: %s
       Annotations:
         tag: %s
-`, imgRef.Context().Name()+"-img2", img2SigDigest, img2SigTag))
+`, imgRef.Context().Name()+"-img2", img2SigDigest, digestSha[0], img2SigTag))
 
+			digestSha = env.ImageFactory.GetImageLayerDigest(img1DigestRef)
 			assert.Contains(t, stdout, fmt.Sprintf(
 				`    - Image: %s
       Type: Image
       Origin: %s
-`, img1DigestRef, img1DigestRef))
+      Layers:
+        - Digest: %s
+`, img1DigestRef, img1DigestRef, digestSha[0]))
 		})
 	})
 }
@@ -359,6 +403,11 @@ images:
 
 			stdoutLines := strings.Split(stdout, "\n")
 			stdout = strings.Join(stdoutLines[:len(stdoutLines)-1], "\n")
+			digestSha1 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + imageDigest)
+			digestSha2 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + bundleSigDigest)
+			digestSha3 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + imgSigDigest)
+			digestSha4 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsImgDigest)
+			digestSha5 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + bundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`sha: %s
 content:
   images:
@@ -368,42 +417,56 @@ content:
         some.other.annotation: some other value
       image: %s%s
       imageType: Image
+      layers:
+      - digest: %s
       origin: %s%s
     "%s":
       annotations:
         tag: %s
       image: %s@%s
       imageType: Signature
+      layers:
+      - digest: %s
       origin: %s@%s
     "%s":
       annotations:
         tag: %s
       image: %s@%s
       imageType: Signature
+      layers:
+      - digest: %s
       origin: %s@%s
     "%s":
       image: %s@%s
       imageType: Internal
+      layers:
+      - digest: %s
       origin: %s@%s
 image: %s%s
+layers:
+- digest: %s
 metadata: {}
 origin: %s%s
 `, bundleDigest[1:],
 				imageDigest[1:],
 				env.RelocationRepo, imageDigest,
+				digestSha1[0],
 				env.Image, imageDigest,
 				bundleSigDigest,
 				bundleSigTag,
 				env.RelocationRepo, bundleSigDigest,
+				digestSha2[0],
 				env.RelocationRepo, bundleSigDigest,
 				imgSigDigest,
 				imgSigTag,
 				env.RelocationRepo, imgSigDigest,
+				digestSha3[0],
 				env.RelocationRepo, imgSigDigest,
 				locationsImgDigest,
 				env.RelocationRepo, locationsImgDigest,
+				digestSha4[0],
 				env.RelocationRepo, locationsImgDigest,
-				env.RelocationRepo, bundleDigest, env.RelocationRepo, bundleDigest), stdout)
+				env.RelocationRepo, bundleDigest, digestSha5[0], env.RelocationRepo, bundleDigest), stdout)
 		})
 	})
 
@@ -456,7 +519,11 @@ images:
 				},
 			)
 			locationsImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(bundleDigest[1:], ":", "-")))
-
+			digestSha1 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + imageDigest)
+			digestSha2 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + bundleSigDigest)
+			digestSha3 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + imgSigDigest)
+			digestSha4 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsImgDigest)
+			digestSha5 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + bundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`content:
   images:
     "%s":
@@ -465,43 +532,53 @@ images:
         some.other.annotation: some other value
       image: %s%s
       imageType: Image
+      layers:
+      - digest: %s
       origin: %s%s
     "%s":
       annotations:
         tag: %s
       image: %s@%s
       imageType: Signature
+      layers:
+      - digest: %s
       origin: %s@%s
     "%s":
       annotations:
         tag: %s
       image: %s@%s
       imageType: Signature
+      layers:
+      - digest: %s
       origin: %s@%s
     "%s":
       image: %s@%s
       imageType: Internal
+      layers:
+      - digest: %s
       origin: %s@%s
 metadata: {}
 image: %s%s
+layers:
+- digest: %s
 origin: %s%s
 sha: %s
 `,
 				imageDigest[1:],
-				env.RelocationRepo, imageDigest,
+				env.RelocationRepo, imageDigest, digestSha1[0],
 				env.Image, imageDigest,
 				bundleSigDigest,
 				bundleSigTag,
-				env.RelocationRepo, bundleSigDigest,
+				env.RelocationRepo, bundleSigDigest, digestSha2[0],
 				env.RelocationRepo, bundleSigDigest,
 				imgSigDigest,
 				imgSigTag,
-				env.RelocationRepo, imgSigDigest,
+				env.RelocationRepo, imgSigDigest, digestSha3[0],
 				env.RelocationRepo, imgSigDigest,
 				locationsImgDigest,
+				env.RelocationRepo, locationsImgDigest, digestSha4[0],
 				env.RelocationRepo, locationsImgDigest,
-				env.RelocationRepo, locationsImgDigest,
-				env.RelocationRepo, bundleDigest, env.RelocationRepo, bundleDigest, bundleDigest[1:]), stdout)
+				env.RelocationRepo, bundleDigest, digestSha5[0], env.RelocationRepo, bundleDigest, bundleDigest[1:]), stdout)
 		})
 	})
 
@@ -576,6 +653,13 @@ images:
 			locationsOuterBundleImgDigest := env.ImageFactory.ImageDigest(fmt.Sprintf("%s:%s.image-locations.imgpkg", env.RelocationRepo, strings.ReplaceAll(outerBundleDigest[1:], ":", "-")))
 			stdoutLines := strings.Split(stdout, "\n")
 			stdout = strings.Join(stdoutLines[:len(stdoutLines)-1], "\n")
+			digestSha1 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
+			digestSha2 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img2Digest)
+			digestSha3 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsNestedBundleImgDigest)
+			digestSha4 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + nestedBundleDigest)
+			digestSha5 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + img1Digest)
+			digestSha6 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + "@" + locationsOuterBundleImgDigest)
+			digestSha7 := env.ImageFactory.GetImageLayerDigest(env.RelocationRepo + outerBundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`sha: %s
 content:
   bundles:
@@ -587,16 +671,24 @@ content:
           "%s":
             image: %s%s
             imageType: Image
+            layers:
+            - digest: %s
             origin: %s
           "%s":
             image: %s%s
             imageType: Image
+            layers:
+            - digest: %s
             origin: %s
           "%s":
             image: %s@%s
             imageType: Internal
+            layers:
+            - digest: %s
             origin: %s@%s
       image: %s%s
+      layers:
+      - digest: %s
       metadata: {}
       origin: %s%s
   images:
@@ -605,29 +697,35 @@ content:
         what is this: this is just an image
       image: %s%s
       imageType: Image
+      layers:
+      - digest: %s
       origin: %s
     "%s":
       image: %s@%s
       imageType: Internal
+      layers:
+      - digest: %s
       origin: %s@%s
 image: %s%s
+layers:
+- digest: %s
 metadata: {}
 origin: %s%s
 `,
 				outerBundleDigest[1:],
 				nestedBundleDigest[1:],
 				img1Digest[1:],
-				env.RelocationRepo, img1Digest, img1DigestRef,
+				env.RelocationRepo, img1Digest, digestSha1[0], img1DigestRef,
 				img2Digest[1:],
-				env.RelocationRepo, img2Digest, img2DigestRef,
+				env.RelocationRepo, img2Digest, digestSha2[0], img2DigestRef,
 				locationsNestedBundleImgDigest,
-				env.RelocationRepo, locationsNestedBundleImgDigest, env.RelocationRepo, locationsNestedBundleImgDigest,
-				env.RelocationRepo, nestedBundleDigest, nestedBundle, nestedBundleDigest,
+				env.RelocationRepo, locationsNestedBundleImgDigest, digestSha3[0], env.RelocationRepo, locationsNestedBundleImgDigest,
+				env.RelocationRepo, nestedBundleDigest, digestSha4[0], nestedBundle, nestedBundleDigest,
 				img1Digest[1:],
-				env.RelocationRepo, img1Digest, img1DigestRef,
+				env.RelocationRepo, img1Digest, digestSha5[0], img1DigestRef,
 				locationsOuterBundleImgDigest,
-				env.RelocationRepo, locationsOuterBundleImgDigest, env.RelocationRepo, locationsOuterBundleImgDigest,
-				env.RelocationRepo, outerBundleDigest, env.RelocationRepo, outerBundleDigest,
+				env.RelocationRepo, locationsOuterBundleImgDigest, digestSha6[0], env.RelocationRepo, locationsOuterBundleImgDigest,
+				env.RelocationRepo, outerBundleDigest, digestSha7[0], env.RelocationRepo, outerBundleDigest,
 			), stdout)
 		})
 	})
@@ -696,6 +794,12 @@ images:
 
 			stdoutLines := strings.Split(stdout, "\n")
 			stdout = strings.Join(stdoutLines[:len(stdoutLines)-1], "\n")
+			digestSha1 := env.ImageFactory.GetImageLayerDigest(img1DigestRef)
+			digestSha2 := env.ImageFactory.GetImageLayerDigest(img2DigestRef)
+			digestSha3 := env.ImageFactory.GetImageLayerDigest(imgRef.Context().Name() + "-img2" + "@" + img2SigDigest)
+			digestSha4 := env.ImageFactory.GetImageLayerDigest(nestedBundle + nestedBundleDigest)
+			digestSha5 := env.ImageFactory.GetImageLayerDigest(img1DigestRef)
+			digestSha6 := env.ImageFactory.GetImageLayerDigest(outerBundle + outerBundleDigest)
 			require.YAMLEq(t, fmt.Sprintf(`sha: %s
 content:
   bundles:
@@ -705,43 +809,55 @@ content:
           "%s":
             image: %s
             imageType: Image
+            layers:
+            - digest: %s
             origin: %s
           "%s":
             image: %s
             imageType: Image
+            layers:
+            - digest: %s
             origin: %s
           "%s":
             annotations:
               tag: %s
             image: %s@%s
             imageType: Signature
+            layers:
+            - digest: %s
             origin: %s@%s
       image: %s%s
+      layers:
+      - digest: %s
       metadata: {}
       origin: %s%s
   images:
     "%s":
       image: %s
       imageType: Image
+      layers:
+      - digest: %s
       origin: %s
 image: %s%s
+layers:
+- digest: %s
 metadata: {}
 origin: %s%s
 `,
 				outerBundleDigest[1:],
 				nestedBundleDigest[1:],
 				img1Digest[1:],
-				img1DigestRef, img1DigestRef,
+				img1DigestRef, digestSha1[0], img1DigestRef,
 				img2Digest[1:],
-				img2DigestRef, img2DigestRef,
+				img2DigestRef, digestSha2[0], img2DigestRef,
 				img2SigDigest,
 				img2SigTag,
+				imgRef.Context().Name()+"-img2", img2SigDigest, digestSha3[0],
 				imgRef.Context().Name()+"-img2", img2SigDigest,
-				imgRef.Context().Name()+"-img2", img2SigDigest,
-				nestedBundle, nestedBundleDigest, nestedBundle, nestedBundleDigest,
+				nestedBundle, nestedBundleDigest, digestSha4[0], nestedBundle, nestedBundleDigest,
 				img1Digest[1:],
-				img1DigestRef, img1DigestRef,
-				outerBundle, outerBundleDigest, outerBundle, outerBundleDigest,
+				img1DigestRef, digestSha5[0], img1DigestRef,
+				outerBundle, outerBundleDigest, digestSha6[0], outerBundle, outerBundleDigest,
 			), stdout)
 		})
 	})

--- a/test/helpers/image_factory.go
+++ b/test/helpers/image_factory.go
@@ -42,6 +42,25 @@ func (i *ImageFactory) ImageDigest(imgRef string) string {
 	return digest.String()
 }
 
+// GetImageLayerDigest will return image's layer digest
+func (i *ImageFactory) GetImageLayerDigest(image string) []string {
+	parsedImgRef, err := name.ParseReference(image, name.WeakValidation)
+	require.NoError(i.T, err)
+
+	v1Img, err := remote.Image(parsedImgRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	require.NoError(i.T, err)
+
+	imgLayers, err := v1Img.Layers()
+	require.NoError(i.T, err)
+	digestSha := []string{}
+	for _, imgLayer := range imgLayers {
+		digHash, err := imgLayer.Digest()
+		require.NoError(i.T, err)
+		digestSha = append(digestSha, digHash.String())
+	}
+	return digestSha
+}
+
 func (i *ImageFactory) PushImageWithANonDistributableLayer(imgRef string, mediaType types.MediaType) string {
 	imageRef, err := name.ParseReference(imgRef, name.WeakValidation)
 	require.NoError(i.T, err)

--- a/test/helpers/image_factory.go
+++ b/test/helpers/image_factory.go
@@ -42,8 +42,8 @@ func (i *ImageFactory) ImageDigest(imgRef string) string {
 	return digest.String()
 }
 
-// GetImageLayerDigest will return image's layer digest
-func (i *ImageFactory) GetImageLayerDigest(image string) []string {
+// GetImageLayersDigest will return image's layers digest
+func (i *ImageFactory) GetImageLayersDigest(image string) []string {
 	parsedImgRef, err := name.ParseReference(image, name.WeakValidation)
 	require.NoError(i.T, err)
 


### PR DESCRIPTION
Fixes https://github.com/carvel-dev/imgpkg/issues/348

**After this changes output will look like:**
```
$ ./imgpkg describe -b k8slt/kc-e2e-test-repo 
Bundle SHA: sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c

Images:
  - Image: index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a
    Type: Bundle
    Origin: index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a
    Layers:
      - Digest: sha256:dc5da8ac3e06c740dc7d82f9e011ef6927ca9893b5dad7e95650f53ba89445df
    Annotations:
      kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v2.0.0
    Images:
    - Image: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
      Type: Image
      Origin: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
      Layers:
        - Digest: sha256:8ece9ac45f2b7228b2ed95e9f407b4f0dc2ac74f93c62ff1156f24c53042ba54
      Annotations:
        kbld.carvel.dev/id: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0

  - Image: index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75
    Type: Bundle
    Origin: index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75
    Layers:
      - Digest: sha256:52bf80eaaecb06062519d66bf59bc8a093cebd37faf48e47fdd79fd009d83612
    Annotations:
      kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v1.0.0
    Images:
    - Image: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
      Type: Image
      Origin: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
      Layers:
        - Digest: sha256:8ece9ac45f2b7228b2ed95e9f407b4f0dc2ac74f93c62ff1156f24c53042ba54
      Annotations:
        kbld.carvel.dev/id: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0

Succeeded
```


**In yaml format:**
```
$ ./imgpkg describe -b k8slt/kc-e2e-test-repo -oyaml
sha: sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c
content:
  bundles:
    sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75:
      annotations:
        kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v1.0.0
      content:
        images:
          sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0:
            annotations:
              kbld.carvel.dev/id: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
            image: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
            imageType: Image
            layers:
            - digest: sha256:8ece9ac45f2b7228b2ed95e9f407b4f0dc2ac74f93c62ff1156f24c53042ba54
            origin: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
      image: index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75
      layers:
      - digest: sha256:52bf80eaaecb06062519d66bf59bc8a093cebd37faf48e47fdd79fd009d83612
      metadata: {}
      origin: index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75
    sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a:
      annotations:
        kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v2.0.0
      content:
        images:
          sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0:
            annotations:
              kbld.carvel.dev/id: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
            image: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
            imageType: Image
            layers:
            - digest: sha256:8ece9ac45f2b7228b2ed95e9f407b4f0dc2ac74f93c62ff1156f24c53042ba54
            origin: index.docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
      image: index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a
      layers:
      - digest: sha256:dc5da8ac3e06c740dc7d82f9e011ef6927ca9893b5dad7e95650f53ba89445df
      metadata: {}
      origin: index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a
image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c
layers:
- digest: sha256:a18d039a28a58cba06a4aaf435e4479b88daeb3cf7a84e1ca1a5d913f56ad1a8
metadata: {}
origin: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c

Succeeded
```