### PR TITLE
Signing and verification added, release notes generation automated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -19,7 +20,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.21.3
-
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@v3
       - name: Retrieve version
         run: |
           echo "TAG_NAME=$(echo ${{ github.ref }}  | grep -Eo 'v[0-9].*')" >> $GITHUB_OUTPUT
@@ -87,7 +89,14 @@ jobs:
             ${checksums['imgpkg-linux-amd64']}  ./imgpkg-linux-amd64
             ${checksums['imgpkg-linux-arm64']}  ./imgpkg-linux-arm64
             ${checksums['imgpkg-windows-amd64.exe']}  ./imgpkg-windows-amd64.exe`
-
+      - name: Verify checksums signature
+        run: |
+          cosign verify-blob \
+          --cert dist/checksums.txt.pem \
+          --signature dist/checksums.txt.sig \
+          --certificate-identity-regexp=https://github.com/carvel-dev \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+          dist/checksums.txt
       - name: verify uploaded artifacts
         if: startsWith(github.ref, 'refs/tags/') && ${{ !env.ACT }}
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,17 @@ checksum:
   name_template: 'checksums.txt'
   algorithm: sha256
   disable: false
+signs:
+  - artifacts: checksum
+    certificate: '${artifact}.pem'
+    cmd: cosign
+    args:
+      - sign-blob
+      - "--yes"
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+    output: true 
 snapshot:
   name_template: "{{ .Tag }}-next"
 release:
@@ -57,6 +68,63 @@ release:
   # You can disable this pipe in order to not upload any artifacts.
   # Defaults to false.
   disable: false
+
+  header: |
+    <details>
+
+    <summary><h2>Installation and signature verification</h2></summary>
+
+    ### Installation
+
+    #### By downloading binary from the release
+
+    For instance, if you are using Linux on an AMD64 architecture:
+    ```shell
+    # Download the binary
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/{{ .ProjectName }}-linux-amd64
+
+    # Move the binary in to your PATH
+    mv imgpkg-linux-amd64 /usr/local/bin/imgpkg
+
+    # Make the binary executable
+    chmod +x /usr/local/bin/imgpkg
+    ```
+
+    #### Via Homebrew (macOS or Linux)
+    ```shell
+    $ brew tap carvel-dev/carvel
+    $ brew install imgpkg
+    $ imgpkg version
+    ```
+
+    ### Verify checksums file signature
+
+    Install cosign on your system https://docs.sigstore.dev/system_config/installation/
+
+    The checksums file provided within the artifacts attached to this release is signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with GitHub OIDC. To validate the signature of this file, run the following commands:
+
+    ```shell
+    # Download the checksums file, certificate and signature
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt.pem
+    curl -LO https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/checksums.txt.sig
+
+    # Verify the checksums file
+    cosign verify-blob checksums.txt \
+      --certificate checksums.txt.pem \
+      --signature checksums.txt.sig \
+      --certificate-identity-regexp=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }} \
+      --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+    ```
+
+    ### Verify binary integrity
+
+    To verify the integrity of the downloaded binary, you can utilize the checksums file after having validated its signature.
+    ```shell
+    # Verify the binary using the checksums file
+    sha256sum -c checksums.txt --ignore-missing
+    ```
+    </details>
 
 changelog:
   # Set it to true if you wish to skip the changelog generation.


### PR DESCRIPTION
Signing and verification added for imgpkg artifacts.
Release notes generation automated for Installation and signature verification.


Release notes will look like:

# ✨ What's new
* a2bcf244 fix

**Full Changelog**: https://github.com/rcmadhankumar/imgpkg/compare/v0.0.29...v0.0.34

<details>

<summary><h2>Installation and signature verification</h2></summary>

### Installation

#### By downloading binary from the release

For instance, if you are using Linux on an AMD64 architecture:
```shell
# Download the binary
curl -LO https://github.com/rcmadhankumar/imgpkg/releases/download/v0.0.34/imgpkg-linux-amd64

# Move the binary in to your PATH
mv imgpkg-linux-amd64 /usr/local/bin/imgpkg

# Make the binary executable
chmod +x /usr/local/bin/imgpkg
```

#### Via Homebrew (macOS or Linux)
```shell
$ brew tap carvel-dev/carvel
$ brew install imgpkg
$ imgpkg version
```

### Verify checksums file signature

Install cosign on your system https://docs.sigstore.dev/system_config/installation/

The checksums file provided within the artifacts attached to this release is signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with GitHub OIDC. To validate the signature of this file, run the following commands:

```shell
# Download the checksums file, certificate and signature
curl -LO https://github.com/rcmadhankumar/imgpkg/releases/download/v0.0.34/checksums.txt
curl -LO https://github.com/rcmadhankumar/imgpkg/releases/download/v0.0.34/checksums.txt.pem
curl -LO https://github.com/rcmadhankumar/imgpkg/releases/download/v0.0.34/checksums.txt.sig

# Verify the checksums file
cosign verify-blob checksums.txt \
  --certificate checksums.txt.pem \
  --signature checksums.txt.sig \
  --certificate-identity-regexp=https://github.com/rcmadhankumar \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
```

### Verify binary integrity

To verify the integrity of the downloaded binary, you can utilize the checksums file after having validated its signature.
```shell
# Verify the binary using the checksums file
sha256sum -c checksums.txt --ignore-missing
```
</details>


# 📂 Files Checksum
```
35a8c6ac2509288c2296a1da6057d182b1b277e3bf59ed8b6d01222fa910058d  ./imgpkg-darwin-arm64
41ddfa974219cb846fe7ae6fa142e3f1a9a19c28ac63c25ea2ac3cb235b4542f  ./imgpkg-darwin-amd64
97762f9e9cc1b7edab7fe464c1eec7635beea64990394a64fb1d17f6ec7b9528  ./imgpkg-windows-amd64.exe
9e3b9c8faabb0b5917191b2e2a571e7d5f7e8851b43887b5978524c35ef31f49  ./imgpkg-linux-amd64
ccdf4aff8cc088f70f6bff28620c6f1c760e2c6188ab8211f9e5444970ad3280  ./imgpkg-linux-arm64
```