### PR TITLE
When 2 images with same SHA are reference by 2 nested bundles

### DIFF
--- a/pkg/imgpkg/imageset/unprocessed_image_refs.go
+++ b/pkg/imgpkg/imageset/unprocessed_image_refs.go
@@ -18,7 +18,14 @@ type UnprocessedImageRef struct {
 	OrigRef   string
 }
 
+// Key that uniquely identify a ImageRef
 func (u UnprocessedImageRef) Key() string {
+	// With this definition of key if one image is shared by 2 bundles
+	// but it is referred in the ImagesLock using a different Registry/Repository
+	// while the SHA is the same, we consider them to be different images, which they are not.
+	// This will lead to duplication of the image in the UnprocessedImageRef that needs to be
+	// address by whoever is using it. This should impact performance of copy because ggcr
+	// will dedupe the Image/Layers based on the SHA.
 	return u.DigestRef + ":" + u.Tag
 }
 


### PR DESCRIPTION
When there are 2 nested bundles that reference the same image (AKA the same SHA) these images are considered as separated images internally. This behavior causes problems when imgpkg is trying to create the Locations image because it searches for the images by SHA, creating a dupplicated entry.

To fix this we decided to force imgpkg to select only one of the entries to add to the Locations list.

This could be averted as well if we stored only 1 copy of these images in the UnprocessedImagesRef struct the main issue is that this is going to hide from imgpkg that the same image is referenced from 2 different sources, this might cause problems in the long run, specially if one day we decide to implement the ability for users to copy bundles to different locations in the destination repository.