### PR TITLE
Limit session IDs to a non-negative, pseudo-random int32

### DIFF
--- a/pkg/imgpkg/registry/registry.go
+++ b/pkg/imgpkg/registry/registry.go
@@ -199,7 +199,7 @@ func NewSimpleRegistryWithTransport(opts Opts, rTripper http.RoundTripper) (*Sim
 
 	sessionID := opts.SessionID
 	if sessionID == "" {
-		sessionID = fmt.Sprint(rand.Intn(9999999999))
+		sessionID = fmt.Sprint(rand.Int31())
 	}
 	baseRoundTripper = NewImgpkgRoundTripper(baseRoundTripper, sessionID)
 


### PR DESCRIPTION
Technically, this reduces the set from which session IDs are drawn by (9.999.999.999 - 2.147.483.647) = 7.852.516.352, say 75%.

Practically, ~2e10 possible session IDs should be large enough to avoid collisions in the real-world.

This fixes an int overflow for 386 architectures.

Fixes #663