### PR TITLE
Increase copy resume performance

### DIFF
--- a/pkg/imgpkg/imageset/tar_image_set.go
+++ b/pkg/imgpkg/imageset/tar_image_set.go
@@ -46,29 +46,21 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 		// This will just follow the normal path of resume == false
 		outputFile, err = os.Open(outputPath)
 		if err == nil {
+			err := outputFile.Close()
+			if err != nil {
+				return nil, err
+			}
 			tmpFile, err = os.CreateTemp("", "imgpkg-tar-imageset-")
 			if err != nil {
 				return nil, fmt.Errorf("Creating tmp folder: %s", err)
 			}
-			defer os.Remove(tmpFile.Name())
+			//defer os.Remove(tmpFile.Name())
+			cErr := os.Rename(outputPath, tmpFile.Name())
+			if cErr != nil {
+				return nil, fmt.Errorf("Moving tar to temporary location: %s", cErr)
+			}
 
 			start := time.Now()
-			var cErr error
-			_, cErr = io.Copy(tmpFile, outputFile)
-			err = tmpFile.Close()
-			if err != nil {
-				return nil, err
-			}
-			err = outputFile.Close()
-			if err != nil {
-				return nil, err
-			}
-			if cErr != nil {
-				return nil, err
-			}
-			i.logger.Debugf("Took %s to copy file", time.Since(start))
-
-			start = time.Now()
 			reader := imagetar.NewTarReader(tmpFile.Name(), i.concurrency)
 			alreadyDownloadedLayers, err = reader.PresentLayers()
 			if err != nil {
@@ -90,27 +82,15 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 	}
 	defer func() {
 		if err == nil {
+			if tmpFile != nil {
+				err = os.Remove(tmpFile.Name())
+			}
 			return
 		}
 		if tmpFile != nil {
-			var err1 error
-			outputFile, err1 = os.Open(outputPath)
-			if err1 != nil {
-				err = fmt.Errorf("original error: %s, post exit error: %s", err, err1)
-				return
-			}
-			lTmpFile, err1 := os.Open(tmpFile.Name())
-			if err1 != nil {
-				outputFile.Close()
-				err = fmt.Errorf("original error: %s, post exit error: %s", err, err1)
-				return
-			}
-
-			_, err1 = io.Copy(outputFile, lTmpFile)
-			outputFile.Close()
-			lTmpFile.Close()
-			if err1 != nil {
-				err = fmt.Errorf("original error: %s, post exit error: %s", err, err1)
+			cErr := os.Rename(tmpFile.Name(), outputPath)
+			if cErr != nil {
+				err = fmt.Errorf("original error: %s, post exit error: %s", err, cErr)
 				return
 			}
 		}

--- a/pkg/imgpkg/imageset/tar_image_set.go
+++ b/pkg/imgpkg/imageset/tar_image_set.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"carvel.dev/imgpkg/pkg/imgpkg/imagedesc"
@@ -40,7 +41,7 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 	// this temporary file is used only in the case were we are resuming the copy of an image to a tar
 	// we are creating a temporary copy of the existing tar. This is done to be able to read the layers
 	// when we are filling up the destination tar.
-	var tmpFile *os.File
+	var tmpFilename string
 	if resume {
 		// If the file cannot be open we assume that this is not a resume action.
 		// This will just follow the normal path of resume == false
@@ -50,18 +51,18 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 			if err != nil {
 				return nil, err
 			}
-			tmpFile, err = os.CreateTemp("", "imgpkg-tar-imageset-")
+			tmpFolder, err := os.MkdirTemp("", "imgpkg-tar-imageset-")
 			if err != nil {
 				return nil, fmt.Errorf("Creating tmp folder: %s", err)
 			}
-			//defer os.Remove(tmpFile.Name())
-			cErr := os.Rename(outputPath, tmpFile.Name())
+			tmpFilename = filepath.Join(tmpFolder, "imgpkg-tar-imageset.tmp")
+			cErr := os.Rename(outputPath, tmpFilename)
 			if cErr != nil {
 				return nil, fmt.Errorf("Moving tar to temporary location: %s", cErr)
 			}
 
 			start := time.Now()
-			reader := imagetar.NewTarReader(tmpFile.Name(), i.concurrency)
+			reader := imagetar.NewTarReader(tmpFilename, i.concurrency)
 			alreadyDownloadedLayers, err = reader.PresentLayers()
 			if err != nil {
 				return nil, fmt.Errorf("Reading previously created tar '%s': %s", outputPath, err)
@@ -82,13 +83,13 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 	}
 	defer func() {
 		if err == nil {
-			if tmpFile != nil {
-				err = os.Remove(tmpFile.Name())
+			if tmpFilename != "" {
+				err = os.Remove(tmpFilename)
 			}
 			return
 		}
-		if tmpFile != nil {
-			cErr := os.Rename(tmpFile.Name(), outputPath)
+		if tmpFilename != "" {
+			cErr := os.Rename(tmpFilename, outputPath)
 			if cErr != nil {
 				err = fmt.Errorf("original error: %s, post exit error: %s", err, cErr)
 				return

--- a/pkg/imgpkg/imageset/tar_image_set.go
+++ b/pkg/imgpkg/imageset/tar_image_set.go
@@ -41,7 +41,7 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 	// this temporary file is used only in the case were we are resuming the copy of an image to a tar
 	// we are creating a temporary copy of the existing tar. This is done to be able to read the layers
 	// when we are filling up the destination tar.
-	var tmpFilename string
+	var tmpFolder, tmpFilename string
 	if resume {
 		// If the file cannot be open we assume that this is not a resume action.
 		// This will just follow the normal path of resume == false
@@ -51,7 +51,7 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 			if err != nil {
 				return nil, err
 			}
-			tmpFolder, err := os.MkdirTemp("", "imgpkg-tar-imageset-")
+			tmpFolder, err = os.MkdirTemp("", "imgpkg-tar-imageset-")
 			if err != nil {
 				return nil, fmt.Errorf("Creating tmp folder: %s", err)
 			}
@@ -83,8 +83,8 @@ func (i *TarImageSet) Export(foundImages *UnprocessedImageRefs, outputPath strin
 	}
 	defer func() {
 		if err == nil {
-			if tmpFilename != "" {
-				err = os.Remove(tmpFilename)
+			if tmpFolder != "" {
+				os.RemoveAll(tmpFolder)
 			}
 			return
 		}

--- a/pkg/imgpkg/imagetar/tar_reader.go
+++ b/pkg/imgpkg/imagetar/tar_reader.go
@@ -117,6 +117,7 @@ func (r *TarReader) presentLayersForImage(img v1.Image, layerCache map[string]v1
 
 			r.throttle.Take()
 			_, err = io.Copy(io.Discard, closer)
+			closer.Close()
 			r.throttle.Done()
 			if err != nil {
 				errChan <- nil

--- a/pkg/imgpkg/v1/copy_test.go
+++ b/pkg/imgpkg/v1/copy_test.go
@@ -282,7 +282,7 @@ func TestToTarImage(t *testing.T) {
 			return false
 		})
 
-		imageTarPath := filepath.Join(os.TempDir(), " imgpkg-test-img.tar")
+		imageTarPath := filepath.Join(os.TempDir(), "imgpkg-test-img.tar")
 		if _, err := os.Stat(imageTarPath); err == nil {
 			os.Remove(imageTarPath)
 		}

--- a/pkg/imgpkg/v1/copy_test.go
+++ b/pkg/imgpkg/v1/copy_test.go
@@ -1210,7 +1210,7 @@ func assertTarballContainsOnlyDistributableLayers(imageTarPath string, t *testin
 		for _, layer := range layers {
 			mediaType, err := layer.MediaType()
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatalf("%s", err.Error())
 			}
 
 			digest, err := layer.Digest()


### PR DESCRIPTION
With this change, we will use the same file provided to be resumed. We do this to increase the performance, previously we were copying the file to the side, which sounds safer but the cost of the
copy vs move is too high.
This change saved almost 20 minutes from a copy that was taking around 1h10.