### PR TITLE
Allow shallow-copy of a bundle

### DIFF
--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -23,14 +23,14 @@ import (
 type CopyOptions struct {
 	ui ui.UI
 
-	ImageFlags         ImageFlags
-	ImageIsBundleCheck bool
-	BundleFlags        BundleFlags
-	LockInputFlags     LockInputFlags
-	LockOutputFlags    LockOutputFlags
-	TarFlags           TarFlags
-	RegistryFlags      RegistryFlags
-	SignatureFlags     SignatureFlags
+	ImageFlags        ImageFlags
+	IgnoreBundleCheck bool
+	BundleFlags       BundleFlags
+	LockInputFlags    LockInputFlags
+	LockOutputFlags   LockOutputFlags
+	TarFlags          TarFlags
+	RegistryFlags     RegistryFlags
+	SignatureFlags    SignatureFlags
 
 	RepoDst string
 
@@ -74,7 +74,7 @@ func NewCopyCmd(o *CopyOptions) *cobra.Command {
 	}
 
 	o.ImageFlags.SetCopy(cmd)
-	cmd.Flags().BoolVar(&o.ImageIsBundleCheck, "image-is-bundle-check", true, "Error when image is a bundle (disable shallow-copying bundles via -i)")
+	cmd.Flags().BoolVar(&o.IgnoreBundleCheck, "ignore-bundle-check", false, "When set to true with -i, imgpkg will not check if the image is a bundle. This enables shallow-copying the bundle image.")
 	o.BundleFlags.SetCopy(cmd)
 	o.LockInputFlags.Set(cmd)
 	o.LockOutputFlags.SetOnCopy(cmd)
@@ -97,8 +97,8 @@ func (c *CopyOptions) Run() error {
 	if !c.hasOneDst() {
 		return fmt.Errorf("Expected either --to-tar or --to-repo")
 	}
-	if !c.ImageIsBundleCheck && len(c.BundleFlags.Bundle) != 0 {
-		return fmt.Errorf("Cannot set --image-is-bundle-check while using -b flag")
+	if c.IgnoreBundleCheck && len(c.BundleFlags.Bundle) != 0 {
+		return fmt.Errorf("Cannot set --ignore-bundle-check while using -b flag")
 	}
 
 	registryOpts := c.RegistryFlags.AsRegistryOpts()
@@ -135,7 +135,7 @@ func (c *CopyOptions) Run() error {
 
 	opts := v1.CopyOpts{
 		Logger:                  levelLogger,
-		AllowShallowCopyBundle:  !c.ImageIsBundleCheck,
+		AllowShallowCopyBundle:  c.IgnoreBundleCheck,
 		ImageSet:                imageSet,
 		TarImageSet:             tarImageSet,
 		Concurrency:             c.Concurrency,

--- a/pkg/imgpkg/cmd/copy.go
+++ b/pkg/imgpkg/cmd/copy.go
@@ -23,13 +23,14 @@ import (
 type CopyOptions struct {
 	ui ui.UI
 
-	ImageFlags      ImageFlags
-	BundleFlags     BundleFlags
-	LockInputFlags  LockInputFlags
-	LockOutputFlags LockOutputFlags
-	TarFlags        TarFlags
-	RegistryFlags   RegistryFlags
-	SignatureFlags  SignatureFlags
+	ImageFlags         ImageFlags
+	ImageIsBundleCheck bool
+	BundleFlags        BundleFlags
+	LockInputFlags     LockInputFlags
+	LockOutputFlags    LockOutputFlags
+	TarFlags           TarFlags
+	RegistryFlags      RegistryFlags
+	SignatureFlags     SignatureFlags
 
 	RepoDst string
 
@@ -73,6 +74,7 @@ func NewCopyCmd(o *CopyOptions) *cobra.Command {
 	}
 
 	o.ImageFlags.SetCopy(cmd)
+	cmd.Flags().BoolVar(&o.ImageIsBundleCheck, "image-is-bundle-check", true, "Error when image is a bundle (disable shallow-copying bundles via -i)")
 	o.BundleFlags.SetCopy(cmd)
 	o.LockInputFlags.Set(cmd)
 	o.LockOutputFlags.SetOnCopy(cmd)
@@ -94,6 +96,9 @@ func (c *CopyOptions) Run() error {
 	}
 	if !c.hasOneDst() {
 		return fmt.Errorf("Expected either --to-tar or --to-repo")
+	}
+	if !c.ImageIsBundleCheck && len(c.BundleFlags.Bundle) != 0 {
+		return fmt.Errorf("Cannot set --image-is-bundle-check while using -b flag")
 	}
 
 	registryOpts := c.RegistryFlags.AsRegistryOpts()
@@ -130,6 +135,7 @@ func (c *CopyOptions) Run() error {
 
 	opts := v1.CopyOpts{
 		Logger:                  levelLogger,
+		AllowShallowCopyBundle:  !c.ImageIsBundleCheck,
 		ImageSet:                imageSet,
 		TarImageSet:             tarImageSet,
 		Concurrency:             c.Concurrency,

--- a/pkg/imgpkg/v1/copy.go
+++ b/pkg/imgpkg/v1/copy.go
@@ -23,6 +23,7 @@ const rootBundleLabelKey string = "dev.carvel.imgpkg.copy.root-bundle"
 type CopyOpts struct {
 	Logger                  Logger
 	ImageSet                ctlimgset.ImageSet
+	AllowShallowCopyBundle  bool
 	TarImageSet             ctlimgset.TarImageSet
 	Concurrency             int
 	SignatureRetriever      SignatureFetcher
@@ -220,7 +221,7 @@ func getProvidedSourceImages(origin CopyOrigin, reg registry.Registry, opts Copy
 		if err != nil {
 			return nil, nil, err
 		}
-		if ok {
+		if ok && !opts.AllowShallowCopyBundle {
 			return nil, nil, fmt.Errorf("Expected bundle flag when copying a bundle (hint: Use -b instead of -i for bundles)")
 		}
 

--- a/pkg/imgpkg/v1/copy.go
+++ b/pkg/imgpkg/v1/copy.go
@@ -217,11 +217,11 @@ func getProvidedSourceImages(origin CopyOrigin, reg registry.Registry, opts Copy
 		opts.Logger.Tracef("copy single image\n")
 		plainImg := plainimage.NewPlainImage(origin.ImageRef, reg)
 
-		ok, err := ctlbundle.NewBundleFromPlainImage(plainImg, reg).IsBundle()
+		isBundle, err := ctlbundle.NewBundleFromPlainImage(plainImg, reg).IsBundle()
 		if err != nil {
 			return nil, nil, err
 		}
-		if ok && !opts.AllowShallowCopyBundle {
+		if isBundle && !opts.AllowShallowCopyBundle {
 			return nil, nil, fmt.Errorf("Expected bundle flag when copying a bundle (hint: Use -b instead of -i for bundles)")
 		}
 

--- a/pkg/imgpkg/v1/copy_test.go
+++ b/pkg/imgpkg/v1/copy_test.go
@@ -126,6 +126,38 @@ bundle:
 
 		assertTarballLabelsOuterBundle(bundleTarPath, origin.BundleRef, t)
 	})
+
+	t.Run("When attemping to shallow-copy without the special flag, it fails", func(t *testing.T) {
+		originForShallowCopy := v1.CopyOrigin{
+			ImageRef: origin.BundleRef,
+		}
+		bundleTarPath := filepath.Join(os.TempDir(), "bundle.tar")
+		defer os.Remove(bundleTarPath)
+
+		_, err := v1.CopyToTar(originForShallowCopy, bundleTarPath, opts, reg)
+		require.ErrorContains(t, err, "Expected bundle flag when copying a bundle (hint: Use -b instead of -i for bundles)")
+	})
+
+	t.Run("When attemping to shallow-copy with the special flag, it succeeds, but only copies the top-level bundle image and not nested images", func(t *testing.T) {
+		originForShallowCopy := v1.CopyOrigin{
+			ImageRef: origin.BundleRef,
+		}
+		bundleTarPath := filepath.Join(os.TempDir(), "bundle.tar")
+		defer os.Remove(bundleTarPath)
+
+		shallowCopyOpts := opts
+		shallowCopyOpts.AllowShallowCopyBundle = true
+
+		_, err := v1.CopyToTar(originForShallowCopy, bundleTarPath, shallowCopyOpts, reg)
+		require.NoError(t, err)
+
+		assertTarballContainsOnlyDistributableLayers(bundleTarPath, t)
+
+		reader := imagetar.NewTarReader(bundleTarPath, 1)
+		layersInTar, err := reader.PresentLayers()
+		require.NoError(t, err)
+		require.Len(t, layersInTar, 1)
+	})
 }
 
 func TestToTarBundleContainingNonDistributableLayers(t *testing.T) {

--- a/test/e2e/copy_from_image_test.go
+++ b/test/e2e/copy_from_image_test.go
@@ -481,7 +481,7 @@ func TestShallowCopyOfBundle(t *testing.T) {
 	registry.Build()
 	defer registry.CleanUp()
 
-	t.Run("when --image-is-bundle-check is NOT provided it fails", func(t *testing.T) {
+	t.Run("when --ignore-bundle-check is NOT provided it fails", func(t *testing.T) {
 		out := bytes.NewBufferString("")
 		_, err := imgpkg.RunWithOpts([]string{"copy", "--tty", "-i", randomBundle.RefDigest, "--to-repo", env.RelocationRepo}, helpers.RunOpts{
 			AllowError:   true,
@@ -493,20 +493,20 @@ func TestShallowCopyOfBundle(t *testing.T) {
 		assert.Contains(t, out.String(), "Expected bundle flag when copying a bundle (hint: Use -b instead of -i for bundles)")
 	})
 
-	t.Run("when --image-is-bundle-check=false is provided while using the -b flag it fails", func(t *testing.T) {
+	t.Run("when --ignore-bundle-check=true is provided while using the -b flag it fails", func(t *testing.T) {
 		out := bytes.NewBufferString("")
-		_, err := imgpkg.RunWithOpts([]string{"copy", "--tty", "-b", randomBundle.RefDigest, "--to-repo", env.RelocationRepo, "--image-is-bundle-check=false"}, helpers.RunOpts{
+		_, err := imgpkg.RunWithOpts([]string{"copy", "--tty", "-b", randomBundle.RefDigest, "--to-repo", env.RelocationRepo, "--ignore-bundle-check"}, helpers.RunOpts{
 			AllowError:   true,
 			StderrWriter: out,
 			StdoutWriter: out,
 		})
 
 		require.Error(t, err)
-		assert.Contains(t, out.String(), "Cannot set --image-is-bundle-check while using -b flag")
+		assert.Contains(t, out.String(), "Cannot set --ignore-bundle-check while using -b flag")
 	})
 
-	t.Run("when --image-is-bundle-check=false is provided it copies the OCI Image of the bundle (shallow copy)", func(t *testing.T) {
-		imgpkg.RunWithOpts([]string{"copy", "--tty", "-i", randomBundle.RefDigest, "--to-repo", env.RelocationRepo, "--image-is-bundle-check=false"}, helpers.RunOpts{})
+	t.Run("when --ignore-bundle-check=true is provided it copies the OCI Image of the bundle (shallow copy)", func(t *testing.T) {
+		imgpkg.RunWithOpts([]string{"copy", "--tty", "-i", randomBundle.RefDigest, "--to-repo", env.RelocationRepo, "--ignore-bundle-check"}, helpers.RunOpts{})
 
 		parts := strings.SplitN(randomBundle.RefDigest, "@", 2)
 		require.Len(t, parts, 2)

--- a/test/e2e/copy_from_image_test.go
+++ b/test/e2e/copy_from_image_test.go
@@ -468,3 +468,49 @@ func startRegistryForAirgapTesting(t *testing.T, env *helpers.Env) (string, *hel
 
 	return fakeRegistry.ReferenceOnTestServer("repo/airgapped-image"), fakeRegistry
 }
+
+func TestShallowCopyOfBundle(t *testing.T) {
+	logger := &helpers.Logger{}
+
+	env := helpers.BuildEnv(t)
+	imgpkg := helpers.Imgpkg{T: t, L: helpers.Logger{}, ImgpkgPath: env.ImgpkgPath}
+	defer env.Cleanup()
+
+	registry := helpers.NewFakeRegistry(t, logger)
+	randomBundle := registry.WithBundleFromPath("repo/some-bundle-name", "assets/bundle")
+	registry.Build()
+	defer registry.CleanUp()
+
+	t.Run("when --image-is-bundle-check is NOT provided it fails", func(t *testing.T) {
+		out := bytes.NewBufferString("")
+		_, err := imgpkg.RunWithOpts([]string{"copy", "--tty", "-i", randomBundle.RefDigest, "--to-repo", env.RelocationRepo}, helpers.RunOpts{
+			AllowError:   true,
+			StderrWriter: out,
+			StdoutWriter: out,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, out.String(), "Expected bundle flag when copying a bundle (hint: Use -b instead of -i for bundles)")
+	})
+
+	t.Run("when --image-is-bundle-check=false is provided while using the -b flag it fails", func(t *testing.T) {
+		out := bytes.NewBufferString("")
+		_, err := imgpkg.RunWithOpts([]string{"copy", "--tty", "-b", randomBundle.RefDigest, "--to-repo", env.RelocationRepo, "--image-is-bundle-check=false"}, helpers.RunOpts{
+			AllowError:   true,
+			StderrWriter: out,
+			StdoutWriter: out,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, out.String(), "Cannot set --image-is-bundle-check while using -b flag")
+	})
+
+	t.Run("when --image-is-bundle-check=false is provided it copies the OCI Image of the bundle (shallow copy)", func(t *testing.T) {
+		imgpkg.RunWithOpts([]string{"copy", "--tty", "-i", randomBundle.RefDigest, "--to-repo", env.RelocationRepo, "--image-is-bundle-check=false"}, helpers.RunOpts{})
+
+		parts := strings.SplitN(randomBundle.RefDigest, "@", 2)
+		require.Len(t, parts, 2)
+		imageWithDigest := env.RelocationRepo + "@" + parts[1]
+		require.NoError(t, env.Assert.ValidateImagesPresenceInRegistry([]string{imageWithDigest}))
+	})
+}


### PR DESCRIPTION
This addresses #757 by adding an new `--ignore-bundle-check` flag to `imgpkg copy`.  That enables shallow-copying a bundle, by treating it like an opaque image.

e.g.
```
imgpkg copy --ignore-bundle-check -i 'example.com/my-bundle:foo' --to-repo 'destination.corp/a-shallow-copy'
```

It also works with `--to-tar` (destination) and `--tar` (source) and with and without `--cosign-signatures` although I didn't add tests specifically for those bits.

Update: originally this flag was `--image-is-bundle-check` (default true) to match the analogous flag on `pull`.  After review, it is now named `--ignore-bundle-check` (default false) to make it more clear.