### PR TITLE
Bump Golang to 1.25.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/imgpkg
 
-go 1.24.9
+go 1.25.3
 
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.9.1


### PR DESCRIPTION
This PR updates the golang version from 1.24.9 to 1.25.3.