### PR TITLE
Remove ghcr workflow run on PR trigger

### DIFF
--- a/.github/workflows/gh-test-external-reg-ghcr.yml
+++ b/.github/workflows/gh-test-external-reg-ghcr.yml
@@ -12,8 +12,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
The external registry check on ghcr can be triggered

1. manually using and workflow_dispatch
2. on push to develop

The manual workflow_dispatch for `test-gh-external-registries-ghcr` check has succeeded
https://github.com/carvel-dev/imgpkg/actions/runs/19057882451/job/54431827100

After this merge it will run only on push to develop and manual trigger