### PR TITLE
Bump golang to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/imgpkg
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.9.1


### PR DESCRIPTION
Bumping golang to 1.25.7 to resolve the below CVEs:

```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                          Title                          │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ CRITICAL │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ crypto/tls: Unexpected session resumption in crypto/tls │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121              │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────────┘
```