### PR TITLE
Reject a tar manifest whose descriptor carries no refs

### DIFF
--- a/pkg/imgpkg/imagedesc/image_ref_descriptors.go
+++ b/pkg/imgpkg/imagedesc/image_ref_descriptors.go
@@ -51,7 +51,47 @@ func NewImageRefDescriptorsFromBytes(data []byte) (*ImageRefDescriptors, error) 
 		return nil, err
 	}
 
+	for _, desc := range descs {
+		switch {
+		case desc.Image != nil:
+			if err := validateImageRefs(*desc.Image); err != nil {
+				return nil, err
+			}
+		case desc.ImageIndex != nil:
+			if err := validateImageIndexRefs(*desc.ImageIndex); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return &ImageRefDescriptors{descs: descs}, nil
+}
+
+// validateImageRefs checks that a descriptor carries the ref that Ref() reads.
+// Every descriptor this package writes has exactly one, but nothing stops a
+// hand-written or truncated manifest from arriving without any.
+func validateImageRefs(desc ImageDescriptor) error {
+	if len(desc.Refs) == 0 {
+		return fmt.Errorf("Expected image descriptor %s to have at least one ref", desc.Manifest.Digest)
+	}
+	return nil
+}
+
+func validateImageIndexRefs(desc ImageIndexDescriptor) error {
+	if len(desc.Refs) == 0 {
+		return fmt.Errorf("Expected image index descriptor %s to have at least one ref", desc.Digest)
+	}
+	for _, img := range desc.Images {
+		if err := validateImageRefs(img); err != nil {
+			return err
+		}
+	}
+	for _, idx := range desc.Indexes {
+		if err := validateImageIndexRefs(idx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func NewImageRefDescriptors(refs []Metadata, registry Registry) (*ImageRefDescriptors, error) {

--- a/pkg/imgpkg/imagedesc/image_ref_descriptors_test.go
+++ b/pkg/imgpkg/imagedesc/image_ref_descriptors_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package imagedesc_test
+
+import (
+	"strings"
+	"testing"
+
+	"carvel.dev/imgpkg/pkg/imgpkg/imagedesc"
+)
+
+func TestNewImageRefDescriptorsFromBytes(t *testing.T) {
+	t.Run("rejects an image descriptor with no refs", func(t *testing.T) {
+		manifest := `[{"Image":{"Refs":[],"Manifest":{"Digest":"sha256:aaaa"}}}]`
+
+		_, err := imagedesc.NewImageRefDescriptorsFromBytes([]byte(manifest))
+		if err == nil {
+			t.Fatal("expected an error, got none")
+		}
+		if !strings.Contains(err.Error(), "at least one ref") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects an image nested in an index with no refs", func(t *testing.T) {
+		manifest := `[{"ImageIndex":{"Refs":["registry.example.com/repo@sha256:bbbb"],"Digest":"sha256:bbbb","Images":[{"Refs":[],"Manifest":{"Digest":"sha256:aaaa"}}]}}]`
+
+		_, err := imagedesc.NewImageRefDescriptorsFromBytes([]byte(manifest))
+		if err == nil {
+			t.Fatal("expected an error, got none")
+		}
+		if !strings.Contains(err.Error(), "at least one ref") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("accepts a descriptor with a ref", func(t *testing.T) {
+		manifest := `[{"Image":{"Refs":["registry.example.com/repo@sha256:aaaa"],"Manifest":{"Digest":"sha256:aaaa"}}}]`
+
+		ids, err := imagedesc.NewImageRefDescriptorsFromBytes([]byte(manifest))
+		if err != nil {
+			t.Fatalf("got an error: %v", err)
+		}
+		if got := len(ids.Descriptors()); got != 1 {
+			t.Errorf("expected 1 descriptor, got %d", got)
+		}
+	})
+}


### PR DESCRIPTION
`DescribedImage.Ref` and `DescribedImageIndex.Ref` both do this:

```go
func (i DescribedImage) Ref() string { return i.desc.Refs[0] }
```

`Refs` is unmarshalled from the `manifest.json` inside a tar (`TarReader.getIdsFromManifest` -> `NewImageRefDescriptorsFromBytes`), so it is whatever the file says. A descriptor with `"Refs": []`, or with the field absent, panics as soon as anything reads the ref:

```
panic: runtime error: index out of range [0] with length 0
```

`TarReader.Read` alone does not trigger it, but `PresentLayers` and the copy path both call `Ref()` on every item, so `imgpkg copy --tar` on a truncated or hand-edited bundle crashes rather than reporting a bad tar. Someone consuming an air-gapped bundle they did not build is exactly the case where the file cannot be assumed well-formed.

Neither `Ref()` has an error to return, and changing them to hand back an empty string only moves the failure to `regname.NewDigest("")` with a worse message. Since every descriptor written by `buildImage`/`buildImageIndex` carries exactly one ref, this checks the invariant while parsing the manifest and names the descriptor that is missing it:

```
Expected image descriptor sha256:aaaa to have at least one ref
```

Images and indexes nested inside an index are walked too, since `buildIndex` calls `NewDescribedImage` on those the same way.

Three cases added in `pkg/imgpkg/imagedesc`. Before the change, parsing a descriptor with no refs succeeds and `Ref()` panics; after it, parsing fails with the message above. `go test ./pkg/imgpkg/...` passes apart from `TestLabels` in `pkg/imgpkg/cmd`, which also fails on a clean checkout here because `IMGPKG_E2E_IMAGE` and `IMGPKG_E2E_RELOCATION_REPO` are not set.
